### PR TITLE
feat: 행사/티켓/회차/부스 관련 기본 엔티티 생성 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// --- JSON ---
+	implementation("com.fasterxml.jackson.core:jackson-databind:2.19.0")
+	implementation("com.fasterxml.jackson.core:jackson-annotations:2.19.0")
+	implementation("com.fasterxml.jackson.core:jackson-core:2.19.0")
 }
 
 sourceSets {

--- a/src/main/java/com/fairing/fairplay/booth/entity/Booth.java
+++ b/src/main/java/com/fairing/fairplay/booth/entity/Booth.java
@@ -1,0 +1,53 @@
+package com.fairing.fairplay.booth.entity;
+
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.user.entity.BoothAdmin;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Booth {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "booth_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booth_type_id", nullable = false)
+    private BoothType boothType;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booth_admin_id")
+    private BoothAdmin boothAdmin;
+
+    @Column(name = "booth_title", nullable = false, length = 100)
+    private String boothTitle;
+
+    @Column(name = "booth_description", nullable = false, columnDefinition = "TEXT")
+    private String boothDescription;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(length = 100)
+    private String location;
+
+    @Column(name = "created_at", columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/fairing/fairplay/booth/entity/BoothApplication.java
+++ b/src/main/java/com/fairing/fairplay/booth/entity/BoothApplication.java
@@ -1,0 +1,59 @@
+package com.fairing.fairplay.booth.entity;
+
+import com.fairing.fairplay.event.entity.Event;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class BoothApplication {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "booth_application_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @Column(name = "booth_title", nullable = false, length = 100)
+    private String boothTitle;
+
+    @Column(name = "booth_description", columnDefinition = "TEXT")
+    private String boothDescription;
+
+    @Column(name = "manager_name", nullable = false, length = 20)
+    private String managerName;
+
+    @Column(nullable = false, length = 100)
+    private String email;
+
+    @Column(name = "contact_number", nullable = false, length = 20)
+    private String contactNumber;
+
+    @Column(name = "official_url", nullable = false, length = 512)
+    private String officialUrl;
+
+    @Column(name = "apply_at", columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime applyAt;
+
+    @Column(name = "admin_comment", columnDefinition = "TEXT")
+    private String adminComment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booth_application_status_code_id", nullable = false)
+    private BoothApplicationStatusCode boothApplicationStatusCode;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booth_payment_status_code_id", nullable = false)
+    private BoothPaymentStatusCode boothPaymentStatusCode;
+
+    @Column(name = "status_updated_at")
+    private LocalDateTime statusUpdatedAt;
+
+}

--- a/src/main/java/com/fairing/fairplay/booth/entity/BoothApplicationStatusCode.java
+++ b/src/main/java/com/fairing/fairplay/booth/entity/BoothApplicationStatusCode.java
@@ -1,0 +1,25 @@
+package com.fairing.fairplay.booth.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "booth_application_status_code")
+public class BoothApplicationStatusCode {
+    // PENDING / APPROVED / REJECTED
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "booth_application_status_code_id")
+    private Integer id;
+
+    @Column(nullable = false, unique = true, length = 20)
+    private String code;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+}

--- a/src/main/java/com/fairing/fairplay/booth/entity/BoothPaymentStatusCode.java
+++ b/src/main/java/com/fairing/fairplay/booth/entity/BoothPaymentStatusCode.java
@@ -1,0 +1,25 @@
+package com.fairing.fairplay.booth.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "booth_payment_status_code")
+public class BoothPaymentStatusCode {
+    // PENDING / PAID / CANCELLED
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "booth_payment_status_code_id")
+    private Integer id;
+
+    @Column(nullable = false, unique = true, length = 20)
+    private String code;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+}

--- a/src/main/java/com/fairing/fairplay/booth/entity/BoothType.java
+++ b/src/main/java/com/fairing/fairplay/booth/entity/BoothType.java
@@ -1,0 +1,29 @@
+package com.fairing.fairplay.booth.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class BoothType {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "booth_type_id")
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 50)
+    private String size;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Column(name = "max_applicants")
+    private Integer maxApplicants;
+
+}

--- a/src/main/java/com/fairing/fairplay/core/util/JsonUtil.java
+++ b/src/main/java/com/fairing/fairplay/core/util/JsonUtil.java
@@ -1,0 +1,36 @@
+package com.fairing.fairplay.core.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public final class JsonUtil {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    private JsonUtil() {
+        // 유틸리티 클래스는 인스턴스화하지 않음
+    }
+
+    public static String toJson(Object obj) {
+        if (obj == null) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(obj);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize object to JSON", e);
+        }
+    }
+
+    public static <T> T fromJson(String json, Class<T> clazz) {
+        if (json == null || json.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(json, clazz);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to deserialize JSON to object", e);
+        }
+    }
+}

--- a/src/main/java/com/fairing/fairplay/event/dto/EventSnapshotDto.java
+++ b/src/main/java/com/fairing/fairplay/event/dto/EventSnapshotDto.java
@@ -1,0 +1,41 @@
+package com.fairing.fairplay.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventSnapshotDto {
+
+    // Fields from Event
+    private String eventCode;
+    private String titleKr;
+    private String titleEng;
+    private boolean hidden;
+    private Long managerId;
+    private Integer eventStatusCodeId;
+
+    // Fields from EventDetail
+    private Long locationId;
+    private String locationDetail;
+    private String hostName;
+    private String contactInfo;
+    private String bio;
+    private String content;
+    private String policy;
+    private String officialUrl;
+    private Integer eventTime;
+    private String thumbnailUrl;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer mainCategoryId;
+    private Integer subCategoryId;
+    private Integer regionCodeId;
+
+}

--- a/src/main/java/com/fairing/fairplay/event/entity/Event.java
+++ b/src/main/java/com/fairing/fairplay/event/entity/Event.java
@@ -1,0 +1,42 @@
+package com.fairing.fairplay.event.entity;
+
+import com.fairing.fairplay.user.entity.EventAdmin;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "event")
+public class Event {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_id")
+    private Long eventId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "manager_id")
+    private EventAdmin manager;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "status_code_id", nullable = false)
+    private EventStatusCode statusCode;
+
+    @Column(name = "event_code", unique = true, nullable = false, length = 50)
+    private String eventCode;
+
+    @Column(name = "title_kr", nullable = false, length = 200)
+    private String titleKr;
+
+    @Column(name = "title_eng", nullable = false, length = 200)
+    private String titleEng;
+
+    @Column(nullable = false)
+    private Boolean hidden = true;
+}

--- a/src/main/java/com/fairing/fairplay/event/entity/EventDetail.java
+++ b/src/main/java/com/fairing/fairplay/event/entity/EventDetail.java
@@ -1,0 +1,81 @@
+package com.fairing.fairplay.event.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "event_detail")
+public class EventDetail {
+
+    @Id
+    private Long eventDetailId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "event_detail_id")
+    private Event event;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id")
+    private Location location;
+
+    @Column(name = "location_detail", length = 255)
+    private String locationDetail;
+
+    @Column(name = "host_name", length = 255)
+    private String hostName;
+
+    @Column(name = "contact_info", columnDefinition = "TEXT")
+    private String contactInfo;
+
+    @Column(length = 255)
+    private String bio;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String policy;
+
+    @Column(name = "official_url", length = 255)
+    private String officialUrl;
+
+    @Column
+    private Integer eventTime;
+
+    @Column(name = "thumbnail_url", length = 255)
+    private String thumbnailUrl;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "main_category", referencedColumnName = "group_id", nullable = false)
+    private MainCategory mainCategory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sub_category", referencedColumnName = "category_id", nullable = false)
+    private SubCategory subCategory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_code_id", nullable = false)
+    private RegionCode regionCode;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/fairing/fairplay/event/entity/EventStatusCode.java
+++ b/src/main/java/com/fairing/fairplay/event/entity/EventStatusCode.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 @Entity
 @Table(name = "event_status_code")
 public class EventStatusCode {
+    // UPCOMING / ONGOING / ENDED
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/fairing/fairplay/event/entity/EventStatusCode.java
+++ b/src/main/java/com/fairing/fairplay/event/entity/EventStatusCode.java
@@ -1,0 +1,28 @@
+package com.fairing.fairplay.event.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "event_status_code")
+public class EventStatusCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_status_code_id")
+    private Integer eventStatusCodeId;
+
+    @Column(length = 20, nullable = false, unique = true)
+    private String code;
+
+    @Column(length = 50, nullable = false)
+    private String name;
+
+}

--- a/src/main/java/com/fairing/fairplay/event/entity/EventVersion.java
+++ b/src/main/java/com/fairing/fairplay/event/entity/EventVersion.java
@@ -1,0 +1,51 @@
+package com.fairing.fairplay.event.entity;
+
+import com.fairing.fairplay.core.util.JsonUtil;
+import com.fairing.fairplay.event.dto.EventSnapshotDto;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "event_version", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"event_id", "version_number"})
+})
+public class EventVersion {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_version_id")
+    private Long eventVersionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private Event event;
+
+    @Column(name = "version_number", nullable = false)
+    private Integer versionNumber;
+
+    @Column(columnDefinition = "JSON")
+    private String snapshot;
+
+    @Column(name = "updated_by", nullable = false)
+    private Long updatedBy;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public EventSnapshotDto getSnapshotAsDto() {
+        return JsonUtil.fromJson(this.snapshot, EventSnapshotDto.class);
+    }
+
+    public void setSnapshotFromDto(EventSnapshotDto dto) {
+        this.snapshot = JsonUtil.toJson(dto);
+    }
+}

--- a/src/main/java/com/fairing/fairplay/event/entity/ExternalLink.java
+++ b/src/main/java/com/fairing/fairplay/event/entity/ExternalLink.java
@@ -1,0 +1,31 @@
+package com.fairing.fairplay.event.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "external_link")
+public class ExternalLink {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "link_id")
+    private Long linkId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private Event event;
+
+    @Column(nullable = false, length = 500)
+    private String url;
+
+    @Column(name = "display_text", length = 50)
+    private String displayText;
+}

--- a/src/main/java/com/fairing/fairplay/event/entity/Location.java
+++ b/src/main/java/com/fairing/fairplay/event/entity/Location.java
@@ -1,0 +1,38 @@
+package com.fairing.fairplay.event.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "location")
+public class Location {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "location_id")
+    private Long locationId;
+
+    @Column(nullable = false, length = 255)
+    private String address;
+
+    @Column(name = "building_name", length = 255)
+    private String buildingName;
+
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal latitude;
+
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal longitude;
+
+    @Column(name = "placeUrl", length = 512)
+    private String placeUrl;
+}

--- a/src/main/java/com/fairing/fairplay/event/entity/MainCategory.java
+++ b/src/main/java/com/fairing/fairplay/event/entity/MainCategory.java
@@ -1,0 +1,23 @@
+package com.fairing.fairplay.event.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "category_group")
+public class MainCategory {
+
+    @Id
+    @Column(name = "group_id")
+    private Integer groupId;
+
+    @Column(name = "group_name", length = 50, nullable = false)
+    private String groupName;
+}

--- a/src/main/java/com/fairing/fairplay/event/entity/RegionCode.java
+++ b/src/main/java/com/fairing/fairplay/event/entity/RegionCode.java
@@ -1,0 +1,27 @@
+package com.fairing.fairplay.event.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "region_code")
+public class RegionCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "region_code_id")
+    private Integer regionCodeId;
+
+    @Column(length = 20, nullable = false, unique = true)
+    private String code;
+
+    @Column(length = 50, nullable = false)
+    private String name;
+}

--- a/src/main/java/com/fairing/fairplay/event/entity/SubCategory.java
+++ b/src/main/java/com/fairing/fairplay/event/entity/SubCategory.java
@@ -1,0 +1,27 @@
+package com.fairing.fairplay.event.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "category")
+public class SubCategory {
+
+    @Id
+    @Column(name = "category_id")
+    private Integer categoryId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private MainCategory mainCategory;
+
+    @Column(name = "category_name", length = 100, nullable = false)
+    private String categoryName;
+}

--- a/src/main/java/com/fairing/fairplay/ticket/dto/TicketSnapshotDto.java
+++ b/src/main/java/com/fairing/fairplay/ticket/dto/TicketSnapshotDto.java
@@ -1,0 +1,25 @@
+package com.fairing.fairplay.ticket.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketSnapshotDto {
+
+    private String name;
+    private String description;
+    private Integer ticketStatusCodeId;
+    private Integer stock;
+    private Integer price;
+    private Integer maxPurchase;
+    private boolean visible;
+    private boolean deleted;
+
+}

--- a/src/main/java/com/fairing/fairplay/ticket/entity/EventSchedule.java
+++ b/src/main/java/com/fairing/fairplay/ticket/entity/EventSchedule.java
@@ -1,0 +1,55 @@
+package com.fairing.fairplay.ticket.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "event_schedule")
+public class EventSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "schedule_id")
+    private Long scheduleId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticket_id", nullable = false)
+    private Ticket ticket;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    private Integer weekday;
+
+    @Column(name = "remaining_stock", nullable = false)
+    private int remainingStock;
+
+    @Column(name = "sales_start_at", nullable = false)
+    private LocalDateTime salesStartAt;
+
+    @Column(name = "sales_end_at", nullable = false)
+    private LocalDateTime salesEndAt;
+
+    @Column(nullable = false)
+    private boolean visible = false;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/fairing/fairplay/ticket/entity/Ticket.java
+++ b/src/main/java/com/fairing/fairplay/ticket/entity/Ticket.java
@@ -1,0 +1,55 @@
+package com.fairing.fairplay.ticket.entity;
+
+import com.fairing.fairplay.event.entity.Event;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "ticket")
+public class Ticket {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ticket_id")
+    private Long ticketId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private Event event;
+
+    @Column(length = 100, nullable = false)
+    private String name;
+
+    @Column(length = 100)
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticket_status_code_id")
+    private TicketStatusCode ticketStatusCode;
+
+    private Integer stock;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Column(name = "max_purchase")
+    private Integer maxPurchase;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private boolean visible = false;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
+}

--- a/src/main/java/com/fairing/fairplay/ticket/entity/TicketStatusCode.java
+++ b/src/main/java/com/fairing/fairplay/ticket/entity/TicketStatusCode.java
@@ -1,0 +1,27 @@
+package com.fairing.fairplay.ticket.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "ticket_status_code")
+public class TicketStatusCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ticket_status_code_id")
+    private Integer ticketStatusCodeId;
+
+    @Column(length = 20, nullable = false, unique = true)
+    private String code;
+
+    @Column(length = 50, nullable = false)
+    private String name;
+}

--- a/src/main/java/com/fairing/fairplay/ticket/entity/TicketVersion.java
+++ b/src/main/java/com/fairing/fairplay/ticket/entity/TicketVersion.java
@@ -1,0 +1,51 @@
+package com.fairing.fairplay.ticket.entity;
+
+import com.fairing.fairplay.core.util.JsonUtil;
+import com.fairing.fairplay.ticket.dto.TicketSnapshotDto;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "ticket_version", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"ticket_id", "version_number"})
+})
+public class TicketVersion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ticket_version_id")
+    private Long ticketVersionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticket_id")
+    private Ticket ticket;
+
+    @Column(name = "version_number", nullable = false)
+    private Integer versionNumber;
+
+    @Column(columnDefinition = "JSON")
+    private String snapshot;
+
+    @Column(name = "updated_by", nullable = false)
+    private Long updatedBy;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public TicketSnapshotDto getSnapshotAsDto() {
+        return JsonUtil.fromJson(this.snapshot, TicketSnapshotDto.class);
+    }
+
+    public void setSnapshotFromDto(TicketSnapshotDto dto) {
+        this.snapshot = JsonUtil.toJson(dto);
+    }
+}

--- a/src/main/java/com/fairing/fairplay/user/entity/BoothAdmin.java
+++ b/src/main/java/com/fairing/fairplay/user/entity/BoothAdmin.java
@@ -1,0 +1,29 @@
+package com.fairing.fairplay.user.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class BoothAdmin {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "booth_admin_id")
+    private Long id;
+
+    @Column(name = "manager_name", nullable = false, length = 20)
+    private String managerName;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(name = "contact_number", nullable = false, length = 20)
+    private String contactNumber;
+
+    @Column(name = "official_url", nullable = false, length = 512)
+    private String officialUrl;
+
+}

--- a/src/main/java/com/fairing/fairplay/user/entity/EventAdmin.java
+++ b/src/main/java/com/fairing/fairplay/user/entity/EventAdmin.java
@@ -1,0 +1,41 @@
+package com.fairing.fairplay.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import com.fairing.fairplay.user.entity.Users;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "event_admin")
+public class EventAdmin {
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    @Id
+    private Users user;
+
+    @Column(nullable = false, length = 20)
+    private String businessNumber;
+
+    @Column(nullable = false, length = 20)
+    private String contactNumber;
+
+    @Column(nullable = false, length = 100)
+    private String contactEmail;
+
+    @Column(nullable = false)
+    private Boolean active = false;
+}
+


### PR DESCRIPTION
### 🛠️ 작업 개요

행사/티켓/회차/부스 관련 기본 엔티티 생성 


### 🧩 작업 상세 내용

- 각각 폴더 따로 생성
- Admin 관련 엔티티는 users 폴더에 생성


### 🔗 관련 이슈

#6, #7, #8, #9
