### PR TITLE
feat: 찜 기능 구현

### DIFF
--- a/src/main/java/com/fairing/fairplay/event/repository/EventRepository.java
+++ b/src/main/java/com/fairing/fairplay/event/repository/EventRepository.java
@@ -1,0 +1,9 @@
+package com.fairing.fairplay.event.repository;
+
+import com.fairing.fairplay.event.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EventRepository extends JpaRepository<Event, Long> {
+}

--- a/src/main/java/com/fairing/fairplay/user/repository/UserRepository.java
+++ b/src/main/java/com/fairing/fairplay/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.fairing.fairplay.user.repository;
+
+import com.fairing.fairplay.user.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<Users, Long> {
+}

--- a/src/main/java/com/fairing/fairplay/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/fairing/fairplay/wishlist/controller/WishlistController.java
@@ -1,0 +1,46 @@
+package com.fairing.fairplay.wishlist.controller;
+
+import com.fairing.fairplay.wishlist.dto.WishlistResponseDto;
+import com.fairing.fairplay.wishlist.service.WishlistService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/wishlist")
+public class WishlistController {
+
+    private final WishlistService wishlistService;
+
+    // 찜 등록
+    @PostMapping
+    public ResponseEntity<Void> addWishlist(
+            @RequestParam Long userId,
+            @RequestParam Long eventId
+    ) {
+        wishlistService.addWishlist(userId, eventId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 찜 취소
+    @DeleteMapping("/{eventId}")
+    public ResponseEntity<Void> cancelWishlist(
+            @RequestParam Long userId,
+            @PathVariable Long eventId
+    ) {
+        wishlistService.cancelWishlist(userId, eventId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 찜 목록 조회
+    @GetMapping
+    public ResponseEntity<List<WishlistResponseDto>> getWishlist(
+            @RequestParam Long userId
+    ) {
+        List<WishlistResponseDto> wishlist = wishlistService.getMyWishlist(userId);
+        return ResponseEntity.ok(wishlist);
+    }
+}

--- a/src/main/java/com/fairing/fairplay/wishlist/dto/WishlistResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/wishlist/dto/WishlistResponseDto.java
@@ -1,0 +1,20 @@
+package com.fairing.fairplay.wishlist.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class WishlistResponseDto {
+
+    private Long eventId;
+    private String eventTitle;
+    private String categoryName;
+    private String location;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer price;
+    private String thumbnailUrl;
+}

--- a/src/main/java/com/fairing/fairplay/wishlist/entity/Wishlist.java
+++ b/src/main/java/com/fairing/fairplay/wishlist/entity/Wishlist.java
@@ -1,0 +1,47 @@
+package com.fairing.fairplay.wishlist.entity;
+
+
+import com.fairing.fairplay.user.entity.Users;
+import com.fairing.fairplay.event.entity.Event;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "wishlist",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "event_id"})
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Wishlist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long wishlistId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private Boolean deleted = false;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/fairing/fairplay/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/fairing/fairplay/wishlist/repository/WishlistRepository.java
@@ -1,0 +1,20 @@
+package com.fairing.fairplay.wishlist.repository;
+
+
+import com.fairing.fairplay.wishlist.entity.Wishlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
+
+    // 유저가 특정 이벤트를 찜했는지 조회 (삭제되지 않은 것만)
+    Optional<Wishlist> findByUser_UserIdAndEvent_EventIdAndDeletedFalse(Long userId, Long eventId);
+
+    // 유저의 찜 목록 전체 조회 (삭제되지 않은 것만)
+    List<Wishlist> findAllByUser_UserIdAndDeletedFalse(Long userId);
+
+    // 유저 + 이벤트로 전체 엔티티 조회 (삭제 여부 상관없이)
+    Optional<Wishlist> findByUser_UserIdAndEvent_EventId(Long userId, Long eventId);
+}

--- a/src/main/java/com/fairing/fairplay/wishlist/service/WishlistService.java
+++ b/src/main/java/com/fairing/fairplay/wishlist/service/WishlistService.java
@@ -1,0 +1,87 @@
+package com.fairing.fairplay.wishlist.service;
+
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.event.repository.EventRepository;
+import com.fairing.fairplay.user.entity.Users;
+import com.fairing.fairplay.user.repository.UserRepository;
+import com.fairing.fairplay.wishlist.dto.WishlistResponseDto;
+import com.fairing.fairplay.wishlist.entity.Wishlist;
+import com.fairing.fairplay.wishlist.repository.WishlistRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class WishlistService {
+
+    private final WishlistRepository wishlistRepository;
+    private final UserRepository userRepository;
+    private final EventRepository eventRepository;
+
+    // 찜 등록
+    @Transactional
+    public void addWishlist(Long userId, Long eventId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new EntityNotFoundException("이벤트를 찾을 수 없습니다."));
+
+        wishlistRepository.findByUser_UserIdAndEvent_EventId(userId, eventId).ifPresentOrElse(
+                wishlist -> {
+                    if (wishlist.getDeleted()) {
+                        wishlist.setDeleted(false);
+                    } else {
+                        throw new IllegalStateException("이미 찜한 이벤트입니다.");
+                    }
+                },
+                () -> {
+                    Wishlist wishlist = Wishlist.builder()
+                            .user(user)
+                            .event(event)
+                            .deleted(false)
+                            .build();
+                    wishlistRepository.save(wishlist);
+                }
+        );
+    }
+
+    // 찜 취소
+    @Transactional
+    public void cancelWishlist(Long userId, Long eventId) {
+        Wishlist wishlist = wishlistRepository.findByUser_UserIdAndEvent_EventIdAndDeletedFalse(userId, eventId)
+                .orElseThrow(() -> new EntityNotFoundException("찜한 이벤트가 없습니다."));
+        wishlist.setDeleted(true);
+    }
+
+    // 찜 목록 조회
+    @Transactional(readOnly = true)
+    public List<WishlistResponseDto> getMyWishlist(Long userId) {
+        List<Wishlist> wishlistList = wishlistRepository.findAllByUser_UserIdAndDeletedFalse(userId);
+
+        return wishlistList.stream()
+                .map(wishlist -> {
+                    Event event = wishlist.getEvent();
+
+                    return WishlistResponseDto.builder()
+                            .eventId(event.getEventId())
+                            .eventTitle(event.getTitleKr())
+                            .categoryName(event.getEventDetail().getMainCategory().getGroupName())
+                            .location(event.getEventDetail().getLocation().getAddress())
+                            .startDate(event.getEventDetail().getStartDate())
+                            .endDate(event.getEventDetail().getEndDate())
+                            .price(event.getTickets().stream()
+                                    .filter(t -> !t.getDeleted())
+                                    .mapToInt(t -> t.getPrice())
+                                    .min()
+                                    .orElse(0))
+                            .thumbnailUrl(event.getEventDetail().getThumbnailUrl())
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 구현 내용
- 찜 등록 API (`POST /api/wishlist`)
- 찜 취소 API (`DELETE /api/wishlist/{eventId}`)
- 찜 목록 조회 API (`GET /api/wishlist`)
- 중복 찜 방지를 위한 unique constraint 적용 (`user_id`, `event_id`)
- soft delete 방식으로 찜 취소 처리 (`deleted = true`)

