### PR TITLE
feat: 찜 목록 조회구현 및 null-safe 처리

### DIFF
--- a/src/main/java/com/fairing/fairplay/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/fairing/fairplay/wishlist/controller/WishlistController.java
@@ -4,6 +4,7 @@ import com.fairing.fairplay.wishlist.dto.WishlistResponseDto;
 import com.fairing.fairplay.wishlist.service.WishlistService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,7 +19,7 @@ public class WishlistController {
     // 찜 등록
     @PostMapping
     public ResponseEntity<Void> addWishlist(
-            @RequestParam Long userId,
+            @AuthenticationPrincipal Long userId,
             @RequestParam Long eventId
     ) {
         wishlistService.addWishlist(userId, eventId);
@@ -28,7 +29,7 @@ public class WishlistController {
     // 찜 취소
     @DeleteMapping("/{eventId}")
     public ResponseEntity<Void> cancelWishlist(
-            @RequestParam Long userId,
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long eventId
     ) {
         wishlistService.cancelWishlist(userId, eventId);
@@ -38,7 +39,7 @@ public class WishlistController {
     // 찜 목록 조회
     @GetMapping
     public ResponseEntity<List<WishlistResponseDto>> getWishlist(
-            @RequestParam Long userId
+            @AuthenticationPrincipal Long userId
     ) {
         List<WishlistResponseDto> wishlist = wishlistService.getMyWishlist(userId);
         return ResponseEntity.ok(wishlist);

--- a/src/main/java/com/fairing/fairplay/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/fairing/fairplay/wishlist/repository/WishlistRepository.java
@@ -3,7 +3,8 @@ package com.fairing.fairplay.wishlist.repository;
 
 import com.fairing.fairplay.wishlist.entity.Wishlist;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,4 +18,14 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
 
     // 유저 + 이벤트로 전체 엔티티 조회 (삭제 여부 상관없이)
     Optional<Wishlist> findByUser_UserIdAndEvent_EventId(Long userId, Long eventId);
+
+    @Query("SELECT w FROM Wishlist w " +
+            "JOIN FETCH w.event e " +
+            "LEFT JOIN FETCH e.eventDetail d " +
+            "LEFT JOIN FETCH d.mainCategory " +
+            "LEFT JOIN FETCH d.location " +
+            "LEFT JOIN FETCH e.eventTickets et " +
+            "LEFT JOIN FETCH et.ticket t " +
+            "WHERE w.user.userId = :userId AND w.deleted = false")
+    List<Wishlist> findWithAllDetailsByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## 구현 내용 
- 찜(Wishlist) 목록 조회 API 구현
- 연관 엔티티 null-safe 처리
- Postman 테스트 완료 (200 OK 및 정상 응답 확인)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 위시리스트 조회 시 관련 이벤트 및 상세 정보가 함께 제공됩니다.

* **버그 수정**
  * 위시리스트 항목 처리 중 일부 연관 데이터가 누락된 경우 예외가 발생하지 않도록 개선되었습니다.

* **기타 변경**
  * 위시리스트 기능에서 사용자 ID를 요청 파라미터 대신 인증 정보를 통해 자동으로 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->