### PR TITLE
feat: 박람회 일정 조회용 캘린더 기능 구현

### DIFF
--- a/src/main/java/com/fairing/fairplay/event/controller/CalendarEventController.java
+++ b/src/main/java/com/fairing/fairplay/event/controller/CalendarEventController.java
@@ -1,0 +1,25 @@
+package com.fairing.fairplay.event.controller;
+
+import com.fairing.fairplay.event.dto.CalendarEventDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.fairing.fairplay.event.service.CalendarEventService;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/calendar")
+public class CalendarEventController {
+
+    private final CalendarEventService calendarEventService;
+
+    @GetMapping("/events")
+    public ResponseEntity<List<CalendarEventDto>> getEventsByMonth(
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        List<CalendarEventDto> events = calendarEventService.getMonthlyEvents(year, month);
+        return ResponseEntity.ok(events);
+    }
+}

--- a/src/main/java/com/fairing/fairplay/event/dto/CalendarEventDto.java
+++ b/src/main/java/com/fairing/fairplay/event/dto/CalendarEventDto.java
@@ -1,0 +1,16 @@
+package com.fairing.fairplay.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class CalendarEventDto {
+    private Long eventId;
+    private String title;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String regionName;
+}

--- a/src/main/java/com/fairing/fairplay/event/repository/CalendarEventRepository.java
+++ b/src/main/java/com/fairing/fairplay/event/repository/CalendarEventRepository.java
@@ -1,0 +1,24 @@
+package com.fairing.fairplay.event.repository;
+
+import com.fairing.fairplay.event.dto.CalendarEventDto;
+import com.fairing.fairplay.event.entity.EventDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface CalendarEventRepository extends JpaRepository<EventDetail, Long> {
+
+    @Query("SELECT new com.fairing.fairplay.event.dto.CalendarEventDto(" +
+            "e.eventId, e.titleKr, ed.startDate, ed.endDate, r.name) " +
+            "FROM Event e " +
+            "JOIN EventDetail ed ON e.eventId = ed.eventDetailId " +
+            "JOIN RegionCode r ON ed.regionCode.regionCodeId = r.regionCodeId " +
+            "WHERE ed.startDate BETWEEN :start AND :end")
+    List<CalendarEventDto> findEventsByMonth(
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end
+    );
+}

--- a/src/main/java/com/fairing/fairplay/event/service/CalendarEventService.java
+++ b/src/main/java/com/fairing/fairplay/event/service/CalendarEventService.java
@@ -1,0 +1,24 @@
+package com.fairing.fairplay.event.service;
+
+import com.fairing.fairplay.event.dto.CalendarEventDto;
+import com.fairing.fairplay.event.repository.CalendarEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarEventService {
+
+    private final CalendarEventRepository calendarEventRepository;
+
+    public List<CalendarEventDto> getMonthlyEvents(int year, int month) {
+        LocalDate start = LocalDate.of(year, month, 1);
+        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+
+        return calendarEventRepository.findEventsByMonth(start, end);
+    }
+}
+


### PR DESCRIPTION
- 월 단위 박람회 일정 데이터를 조회하는 캘린더 API 구현
- 연/월(year, month)을 파라미터로 받아 해당 월의 행사 목록 반환
- 반환 데이터는 행사 ID, 제목, 시작일, 종료일, 지역명을 포함
- 수정 , 테스트 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 연도와 월을 기준으로 해당 월의 캘린더 이벤트 목록을 조회할 수 있는 API가 추가되었습니다.
  * 각 이벤트는 제목, 시작일, 종료일, 지역명 등의 정보를 포함합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->