### PR TITLE
feat:카카오 로그인 구현

### DIFF
--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -37,7 +37,8 @@ public class SecurityConfig {
                                 "/api/users/check-email",
                                 "/api/users/check-nickname",
                                 "/api/email/verify-code",
-                                "/api/email/send-verification"
+                                "/api/email/send-verification",
+                                "/api/auth/kakao"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/fairing/fairplay/core/controller/AuthController.java
+++ b/src/main/java/com/fairing/fairplay/core/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.fairing.fairplay.core.controller;
 
+import com.fairing.fairplay.core.dto.KakaoLoginRequest;
 import com.fairing.fairplay.core.dto.LoginRequest;
 import com.fairing.fairplay.core.dto.LoginResponse;
 import com.fairing.fairplay.core.dto.RefreshTokenRequest;
@@ -39,4 +40,11 @@ public class AuthController {
         LoginResponse response = authService.refreshToken(request.getRefreshToken());
         return ResponseEntity.ok(response);
     }
+
+    @PostMapping("/kakao")
+    public ResponseEntity<LoginResponse> kakaoLogin(@RequestBody KakaoLoginRequest request) {
+        LoginResponse response = authService.kakaoLogin(request.getCode());
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/fairing/fairplay/core/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/fairing/fairplay/core/dto/KakaoLoginRequest.java
@@ -1,0 +1,9 @@
+// src/main/java/com/fairing/fairplay/core/dto/KakaoLoginRequest.java
+package com.fairing.fairplay.core.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoLoginRequest {
+    private String code;
+}

--- a/src/main/java/com/fairing/fairplay/core/service/AuthService.java
+++ b/src/main/java/com/fairing/fairplay/core/service/AuthService.java
@@ -5,19 +5,51 @@ import com.fairing.fairplay.core.dto.LoginRequest;
 import com.fairing.fairplay.core.dto.LoginResponse;
 import com.fairing.fairplay.core.util.JwtTokenProvider;
 import com.fairing.fairplay.user.entity.Users;
+import com.fairing.fairplay.user.entity.UserRoleCode;
 import com.fairing.fairplay.user.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import com.fairing.fairplay.user.repository.UserRoleCodeRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 
 @Service
-@RequiredArgsConstructor
 public class AuthService {
+
     private final UserRepository userRepository;
+    private final UserRoleCodeRepository userRoleCodeRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
+
+    private final String kakaoClientId;
+    private final String kakaoRedirectUri;
+    private final String kakaoClientSecret;
+
+    public AuthService(
+            UserRepository userRepository,
+            UserRoleCodeRepository userRoleCodeRepository,
+            PasswordEncoder passwordEncoder,
+            JwtTokenProvider jwtTokenProvider,
+            RefreshTokenService refreshTokenService,
+            @Value("${kakao.client-id}") String kakaoClientId,
+            @Value("${kakao.redirect-uri}") String kakaoRedirectUri,
+            @Value("${kakao.client-secret:}") String kakaoClientSecret
+    ) {
+        this.userRepository = userRepository;
+        this.userRoleCodeRepository = userRoleCodeRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.refreshTokenService = refreshTokenService;
+        this.kakaoClientId = kakaoClientId;
+        this.kakaoRedirectUri = kakaoRedirectUri;
+        this.kakaoClientSecret = kakaoClientSecret;
+    }
 
     // 로그인 + JWT 발급
     public LoginResponse login(LoginRequest request) {
@@ -89,4 +121,108 @@ public class AuthService {
 
         return new LoginResponse(newAccessToken, newRefreshToken);
     }
+
+    public LoginResponse kakaoLogin(String code) {
+        // 1. 카카오 토큰 요청
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoClientId);
+        params.add("redirect_uri", kakaoRedirectUri);
+        params.add("code", code);
+        if (kakaoClientSecret != null && !kakaoClientSecret.isBlank()) {
+            params.add("client_secret", kakaoClientSecret);
+        }
+
+        HttpEntity<MultiValueMap<String, String>> tokenRequest = new HttpEntity<>(params, headers);
+
+        ResponseEntity<String> tokenResponse = restTemplate.postForEntity(
+                "https://kauth.kakao.com/oauth/token",
+                tokenRequest,
+                String.class
+        );
+
+        String accessToken;
+        try {
+            ObjectMapper om = new ObjectMapper();
+            JsonNode node = om.readTree(tokenResponse.getBody());
+            accessToken = node.get("access_token").asText();
+        } catch (Exception e) {
+            throw new CustomException(HttpStatus.UNAUTHORIZED, "카카오 토큰 발급 실패");
+        }
+
+        // 2. 카카오 유저 정보 요청
+        HttpHeaders userInfoHeaders = new HttpHeaders();
+        userInfoHeaders.set("Authorization", "Bearer " + accessToken);
+        HttpEntity<?> userInfoRequest = new HttpEntity<>(userInfoHeaders);
+
+        ResponseEntity<String> userInfoResponse = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET,
+                userInfoRequest,
+                String.class
+        );
+
+        String kakaoId = null;
+        String nickname = null;
+        try {
+            ObjectMapper om = new ObjectMapper();
+            JsonNode userNode = om.readTree(userInfoResponse.getBody());
+            kakaoId = userNode.get("id").asText(); // 카카오 고유 userId
+            JsonNode kakaoAccount = userNode.get("kakao_account");
+            if (kakaoAccount != null && kakaoAccount.has("profile")) {
+                nickname = kakaoAccount.get("profile").get("nickname").asText();
+            }
+        } catch (Exception e) {
+            throw new CustomException(HttpStatus.UNAUTHORIZED, "카카오 유저 정보 파싱 실패");
+        }
+
+        if (kakaoId == null || kakaoId.isBlank()) {
+            throw new CustomException(HttpStatus.UNAUTHORIZED, "카카오 아이디 수신 실패");
+        }
+
+        // 임시 이메일 생성 (kakao_1234567890)
+        final String tempEmail = "kakao_" + kakaoId;
+        final String finalNickname = nickname != null ? nickname : "kakaoUser";
+
+        Users user = userRepository.findByEmail(tempEmail)
+                .orElseGet(() -> {
+                    // 기본 권한 COMMON 코드 엔티티 할당 (없으면 예외)
+                    UserRoleCode userRole = userRoleCodeRepository.findByCode("COMMON")
+                            .orElseThrow(() -> new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "기본 권한 코드(COMMON)가 없습니다."));
+                    // 신규 소셜 회원가입
+                    Users newUser = Users.builder()
+                            .email(tempEmail)
+                            .nickname(finalNickname)
+                            .password(passwordEncoder.encode("kakao_social")) // 소셜로그인용 비번(임의)
+                            .roleCode(userRole)
+                            .name(finalNickname)
+                            .phone("01000000000") // 더미값, 추후 수정
+                            .build();
+                    userRepository.save(newUser);
+                    return newUser;
+                });
+
+        // JWT, refreshToken 발급
+        String ourAccessToken = jwtTokenProvider.generateAccessToken(
+                user.getUserId(),
+                user.getEmail(),
+                user.getRoleCode().getName()
+        );
+        String ourRefreshToken = jwtTokenProvider.generateRefreshToken(
+                user.getUserId(),
+                user.getEmail()
+        );
+        refreshTokenService.saveRefreshToken(
+                user.getUserId(),
+                ourRefreshToken,
+                jwtTokenProvider.getRefreshTokenExpiry()
+        );
+
+        return new LoginResponse(ourAccessToken, ourRefreshToken);
+    }
+
 }

--- a/src/main/java/com/fairing/fairplay/user/controller/UserController.java
+++ b/src/main/java/com/fairing/fairplay/user/controller/UserController.java
@@ -64,7 +64,7 @@ public class UserController {
     // 임시 비밀번호 전송
     @PostMapping("/forgot-password")
     public ResponseEntity<Void> forgotPassword(@RequestBody UserForgotPasswordRequestDto dto) {
-        userService.sendTemporaryPassword(dto.getEmail(), dto.getName());
+        userService.sendTemporaryPassword(dto.getEmail());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/fairing/fairplay/user/dto/UserForgotPasswordRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/user/dto/UserForgotPasswordRequestDto.java
@@ -5,5 +5,4 @@ import lombok.Getter;
 @Getter
 public class UserForgotPasswordRequestDto {
     private String email;
-    private String name; //
 }

--- a/src/main/java/com/fairing/fairplay/user/entity/EmailVerification.java
+++ b/src/main/java/com/fairing/fairplay/user/entity/EmailVerification.java
@@ -24,5 +24,6 @@ public class EmailVerification {
     private LocalDateTime expiresAt;
 
     @Column(nullable = false)
+    @Builder.Default
     private Boolean verified = false;
 }

--- a/src/main/java/com/fairing/fairplay/user/service/UserService.java
+++ b/src/main/java/com/fairing/fairplay/user/service/UserService.java
@@ -48,6 +48,9 @@ public class UserService {
         userRepository.save(user);
     }
 
+
+
+
     @Transactional(readOnly = true)
     public UserResponseDto getMyInfo(Long userId) {
         Users user = userRepository.findById(userId)
@@ -101,8 +104,8 @@ public class UserService {
     }
 
     @Transactional
-    public void sendTemporaryPassword(String email, String name) {
-        Users user = userRepository.findByEmailAndName(email, name)
+    public void sendTemporaryPassword(String email) {
+        Users user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("일치하는 회원이 없습니다."));
 
         String tempPassword = generateRandomPassword(10);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,3 +52,8 @@ jwt:
   refresh-token-validity-ms: 172800000  # 2일(172,800,000 ms)
   refresh-token-prefix: "refresh_token:"
 
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+  client-secret: ${KAKAO_CLIENT_SECRET:}


### PR DESCRIPTION
임시비밀번호 발급시 이름 받던 dto 삭제, 카카오 로그인 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 카카오 소셜 로그인을 위한 인증 API 엔드포인트가 추가되었습니다.
  * 카카오 로그인을 위한 설정 항목이 환경 변수로 추가되었습니다.

* **버그 수정**
  * 임시 비밀번호 발급 시 이름 입력 없이 이메일만으로 요청할 수 있도록 개선되었습니다.

* **기타**
  * 이메일 인증 엔티티의 기본값 처리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->