### PR TITLE
feat: 폼 링크 자동 만료 및 QR 티켓 기본 세팅 구현

### DIFF
--- a/src/main/java/com/fairing/fairplay/attendee/controller/AttendeeController.java
+++ b/src/main/java/com/fairing/fairplay/attendee/controller/AttendeeController.java
@@ -24,7 +24,7 @@ public class AttendeeController {
 
   private final AttendeeService attendeeService;
 
-  // 폼링크 요청
+  // 폼링크 통한 참석자 저장 -> 동반자만. 대표자는 예약과 동시 저장
   @PostMapping
   public ResponseEntity<AttendeeInfoResponseDto> saveAttendee(@RequestParam String token,
       @RequestBody AttendeeSaveRequestDto dto) {

--- a/src/main/java/com/fairing/fairplay/attendee/entity/Attendee.java
+++ b/src/main/java/com/fairing/fairplay/attendee/entity/Attendee.java
@@ -1,5 +1,6 @@
 package com.fairing.fairplay.attendee.entity;
 
+import com.fairing.fairplay.reservation.entity.Reservation;
 import jakarta.persistence.Id;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -31,18 +32,11 @@ public class Attendee {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "attendee_id", nullable = false, updatable = false)
-
   private Long id;
 
-  /*
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "reservation_id")
   private Reservation reservation;
-  */
-  // 임시 설정
-
-  @Column(name = "reservation_id", nullable = false)
-  private Long reservationId;
 
   @Column(name = "name", nullable = true)
   private String name;

--- a/src/main/java/com/fairing/fairplay/attendee/repository/AttendeeRepository.java
+++ b/src/main/java/com/fairing/fairplay/attendee/repository/AttendeeRepository.java
@@ -7,11 +7,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AttendeeRepository extends JpaRepository<Attendee, Long> {
 
-  Optional<List<Attendee>> findAllByReservationId(Long reservationId);
+  List<Attendee> findAllByReservation_ReservationId(Long reservationId);
 
-  Optional<Attendee> findByReservationIdAndAttendeeTypeCode_Id(Long reservationId,
+  Optional<Attendee> findByReservation_ReservationIdAndAttendeeTypeCode_Id(Long reservationId,
       Integer attendeeTypeCodeId);
 
-  Optional<Attendee> findByIdAndReservationIdAndAttendeeTypeCode_Id(Long attendeeId,
+  Optional<Attendee> findByIdAndReservation_ReservationIdAndAttendeeTypeCode_Id(Long attendeeId,
       Long reservationId, Integer attendeeTypeCodeId);
 }

--- a/src/main/java/com/fairing/fairplay/core/config/SchedulingConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SchedulingConfig.java
@@ -1,0 +1,24 @@
+package com.fairing.fairplay.core.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+@EnableScheduling
+@EnableAsync
+public class SchedulingConfig implements SchedulingConfigurer {
+
+  // 최대 10 개 스케줄 작업이 동시에 실행 가능
+  @Override
+  public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+    ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+    scheduler.setPoolSize(10);  // 스레드 10개 할당
+    scheduler.initialize();
+
+    taskRegistrar.setTaskScheduler(scheduler);
+  }
+}

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketInitProvider.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketInitProvider.java
@@ -22,7 +22,7 @@ public class QrTicketInitProvider {
 
     if (attendeeTypeCodeId == 1) {
       // 대표자: 예약 ID + 타입으로 한 명만 조회
-      attendee = attendeeRepository.findByReservationIdAndAttendeeTypeCode_Id(
+      attendee = attendeeRepository.findByReservation_ReservationIdAndAttendeeTypeCode_Id(
               dto.getReservationId(), attendeeTypeCodeId)
           .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "참석자를 조회할 수 없습니다."));
 
@@ -32,7 +32,7 @@ public class QrTicketInitProvider {
         throw new CustomException(HttpStatus.BAD_REQUEST, "대표자가 아니므로 조회할 수 없습니다.");
       }
 
-      attendee = attendeeRepository.findByIdAndReservationIdAndAttendeeTypeCode_Id(
+      attendee = attendeeRepository.findByIdAndReservation_ReservationIdAndAttendeeTypeCode_Id(
               dto.getAttendeeId(), dto.getReservationId(), attendeeTypeCodeId)
           .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "동반 참석자를 조회할 수 없습니다."));
 

--- a/src/main/java/com/fairing/fairplay/scheduler/QrTicketScheduler.java
+++ b/src/main/java/com/fairing/fairplay/scheduler/QrTicketScheduler.java
@@ -1,4 +1,4 @@
-package com.fairing.fairplay.qr.scheduler;
+package com.fairing.fairplay.scheduler;
 
 import com.fairing.fairplay.qr.service.QrTicketService;
 import lombok.RequiredArgsConstructor;
@@ -10,12 +10,6 @@ public class QrTicketScheduler {
 
   private final QrTicketService qrTicketService;
 
-//  // 매일 자정 QR 티켓 세팅
-//  @Scheduled(cron = "0 0 0 * * *")
-//  public void runCreateQrTicket() {
-//    qrTicketService.createQrTicket();
-//  }
-//
 //  // 매일 오전 9시 티켓 전송
 //  @Scheduled(cron = "0 0 09 * * *")
 //  public void runSendQrTicket(){

--- a/src/main/java/com/fairing/fairplay/scheduler/ShareTicketQrScheduler.java
+++ b/src/main/java/com/fairing/fairplay/scheduler/ShareTicketQrScheduler.java
@@ -14,26 +14,38 @@ public class ShareTicketQrScheduler {
 
   private final ShareTicketService shareTicketService;
   private final QrTicketService qrTicketService;
-
+/*
   // 공유 폼 링크 만료
   @Scheduled(cron = "0 0 0 * * *") //매일 자정 실행
   public void runDailyTasks() {
-    int batchSize = 100; //한번에 처리할 개수
+    int batchSize = 100; //
     int page = 0;
+    int maxIterations = 1000; // 무한루프 방지
+    int currentIteration = 0;
 
     // 1. 만료 처리
     while (true) {
-      List<ShareTicket> batch = shareTicketService.fetchExpiredBatch(page, batchSize);
-      if (batch.isEmpty()) {
+      if (currentIteration >= maxIterations) {
+        // 로깅 및 알림 로직 추가
         break;
       }
 
-      shareTicketService.expiredToken(batch);
-      page++;
-    }
+      try {
+        List<ShareTicket> batch = shareTicketService.fetchExpiredBatch(page, batchSize);
+        if (batch.isEmpty()) {
+          break;
+        }
 
+        shareTicketService.expiredToken(batch);
+        page++;
+
+      } catch (Exception e) {
+        page++;
+        currentIteration++;
+      }
+    }
     // 2. 만료 완료 후 QR 티켓 세팅
     qrTicketService.createQrTicket();
   }
-
+  */
 }

--- a/src/main/java/com/fairing/fairplay/shareticket/dto/ShareTicketSaveRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/dto/ShareTicketSaveRequestDto.java
@@ -1,5 +1,6 @@
 package com.fairing.fairplay.shareticket.dto;
 
+import com.fairing.fairplay.reservation.entity.Reservation;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,7 +9,7 @@ import lombok.Getter;
 @Builder
 public class ShareTicketSaveRequestDto {
 
-  private Long reservationId;
+  private Reservation reservation;
   private int totalAllowed;
   private LocalDateTime expiredAt;
 }

--- a/src/main/java/com/fairing/fairplay/shareticket/dto/ShareTicketSaveRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/dto/ShareTicketSaveRequestDto.java
@@ -1,6 +1,5 @@
 package com.fairing.fairplay.shareticket.dto;
 
-import com.fairing.fairplay.reservation.entity.Reservation;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,7 +8,7 @@ import lombok.Getter;
 @Builder
 public class ShareTicketSaveRequestDto {
 
-  private Reservation reservation;
+  private Long reservationId;
   private int totalAllowed;
   private LocalDateTime expiredAt;
 }

--- a/src/main/java/com/fairing/fairplay/shareticket/entity/ShareTicket.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/entity/ShareTicket.java
@@ -1,10 +1,14 @@
 package com.fairing.fairplay.shareticket.entity;
 
+import com.fairing.fairplay.reservation.entity.Reservation;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -29,15 +33,16 @@ public class ShareTicket {
   @Column(name = "share_ticket_id")
   private Long id;
 
-  // Reservation 엔티티 생성 시 수정
-  @Column(name = "reservation_id")
-  private Long reservationId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "reservation_id", nullable = false)
+  private Reservation reservation;
 
   @Column(name = "link_token", nullable = false, unique = true)
   private String linkToken;
 
   @Column(name = "submitted_count", nullable = false)
   @ColumnDefault("0")
+  @Builder.Default
   private Integer submittedCount = 0;
 
   @Column(name = "total_allowed", nullable = false)
@@ -45,6 +50,7 @@ public class ShareTicket {
 
   @Column(name = "expired", nullable = false)
   @ColumnDefault("false")
+  @Builder.Default
   private Boolean expired = false;
 
   @CreationTimestamp

--- a/src/main/java/com/fairing/fairplay/shareticket/repository/ShareTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/repository/ShareTicketRepository.java
@@ -1,10 +1,13 @@
 package com.fairing.fairplay.shareticket.repository;
 
 import com.fairing.fairplay.shareticket.entity.ShareTicket;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ShareTicketRepository extends JpaRepository<ShareTicket, Long> {
 
   Optional<ShareTicket> findByLinkToken(String linkToken);
+  List<ShareTicket> findAllByExpiredAtBetween(LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/fairing/fairplay/shareticket/repository/ShareTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/repository/ShareTicketRepository.java
@@ -4,10 +4,13 @@ import com.fairing.fairplay.shareticket.entity.ShareTicket;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ShareTicketRepository extends JpaRepository<ShareTicket, Long> {
 
   Optional<ShareTicket> findByLinkToken(String linkToken);
-  List<ShareTicket> findAllByExpiredAtBetween(LocalDateTime startDate, LocalDateTime endDate);
+
+  List<ShareTicket> findAllByExpiredAtBetweenAndExpiredFalse(LocalDateTime startDate, LocalDateTime endDate,
+      Pageable pageable);
 }

--- a/src/main/java/com/fairing/fairplay/shareticket/repository/ShareTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/repository/ShareTicketRepository.java
@@ -13,4 +13,6 @@ public interface ShareTicketRepository extends JpaRepository<ShareTicket, Long> 
 
   List<ShareTicket> findAllByExpiredAtBetweenAndExpiredFalse(LocalDateTime startDate, LocalDateTime endDate,
       Pageable pageable);
+
+  boolean existsByLinkToken(String token);
 }

--- a/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketService.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketService.java
@@ -110,7 +110,7 @@ public class ShareTicketService {
     shareTickets.forEach(shareTicket -> {
       shareTicket.setExpired(true);
       shareTicket.setExpiredAt(LocalDateTime.now());
-      shareTicketRepository.save(shareTicket);
     });
+    shareTicketRepository.saveAll(shareTickets);
   }
 }


### PR DESCRIPTION
## 변경 사항
- QR 티켓 스케줄러 수정
- 폼 링크 관련 스케줄러 추가 
- 폼 링크 만료 및 QR 티켓 기본 세팅 매일 자정 00시 실행

## 관련 이슈
#36 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 예약과의 연관관계를 JPA 엔티티 참조 방식으로 개선하여 데이터 일관성을 강화했습니다.
  * 만료된 공유 티켓을 일괄 처리하고 QR 티켓을 생성하는 스케줄러 구성을 추가했습니다.
  * 공유 티켓의 만료 여부 및 토큰 존재 여부를 확인하는 기능이 추가되었습니다.
  * 스케줄링 및 비동기 처리를 위한 설정이 도입되었습니다.
  * 공유 티켓 토큰 생성, 검증, 갱신 기능이 추가되었습니다.
  
* **버그 수정**
  * 예약 존재 여부를 검증하여 잘못된 예약 ID 사용을 방지합니다.

* **리팩터링**
  * 여러 메서드에서 예약 ID 대신 예약 엔티티 참조를 사용하도록 변경하여 코드 일관성을 높였습니다.
  * 리포지토리 메서드 명칭을 엔티티 구조에 맞게 수정했습니다.

* **문서화**
  * 일부 메서드의 주석을 더 명확하게 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->