### PR TITLE
feat: 찜 등록/취소/조회 기능 수정 및 응답 메시지 추가

### DIFF
--- a/src/main/java/com/fairing/fairplay/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/fairing/fairplay/wishlist/controller/WishlistController.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
+import com.fairing.fairplay.core.security.CustomUserDetails;
 import java.util.List;
 
 @RestController
@@ -18,29 +18,32 @@ public class WishlistController {
 
     // 찜 등록
     @PostMapping
-    public ResponseEntity<Void> addWishlist(
-            @AuthenticationPrincipal Long userId,
+    public ResponseEntity<String> addWishlist(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam Long eventId
     ) {
+        Long userId = userDetails.getUserId();
         wishlistService.addWishlist(userId, eventId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok("찜 등록이 완료되었습니다.");
     }
 
     // 찜 취소
     @DeleteMapping("/{eventId}")
-    public ResponseEntity<Void> cancelWishlist(
-            @AuthenticationPrincipal Long userId,
+    public ResponseEntity<String> cancelWishlist(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long eventId
     ) {
+        Long userId = userDetails.getUserId();
         wishlistService.cancelWishlist(userId, eventId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok("삭제되었습니다.");
     }
 
     // 찜 목록 조회
     @GetMapping
     public ResponseEntity<List<WishlistResponseDto>> getWishlist(
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        Long userId = userDetails.getUserId();
         List<WishlistResponseDto> wishlist = wishlistService.getMyWishlist(userId);
         return ResponseEntity.ok(wishlist);
     }


### PR DESCRIPTION
## 구현 내용
- 찜 등록 기능 (`POST /api/wishlist`)
- 찜 취소 기능 (`DELETE /api/wishlist/{eventId}`)
- 찜 목록 조회 기능 (`GET /api/wishlist`)
- 사용자 응답 메시지 추가 (등록/삭제 완료 메시지 반환)
- null-safe DTO 변환 로직 적용

## 인증 방식
- JWT 기반 인증 적용
- `@AuthenticationPrincipal`을 통해 userId 추출

## 테스트
- Postman을 통해 등록/삭제/조회 동작 확인
