### PR TITLE
feat: QR 티켓 조회 및 발급 구현

### DIFF
--- a/src/main/java/com/fairing/fairplay/core/config/QuerydslConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.fairing.fairplay.core.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+  @Bean
+  public JPAQueryFactory queryFactory(EntityManager em) {
+    return new JPAQueryFactory(em);
+  }
+}

--- a/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
+++ b/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
@@ -7,6 +7,7 @@ import com.fairing.fairplay.qr.service.QrTicketService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,6 +26,10 @@ public class QrTicketController {
   }
 
   // 비회원 QR 티켓 조회 (참석자)
+  @GetMapping("/{token}")
+  public ResponseEntity<QrTicketResponseDto> issueGuest(@PathVariable String token) {
+    return ResponseEntity.ok(qrTicketService.issueGuest(token));
+  }
 
   // QR 티켓 만료
 

--- a/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
+++ b/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,7 +21,7 @@ public class QrTicketController {
   private final QrTicketService qrTicketService;
 
   // 마이페이지에서 QR 티켓 조회
-  @GetMapping
+  @PostMapping
   public ResponseEntity<QrTicketResponseDto> issueMember(@RequestBody QrTicketRequestDto dto) {
     return ResponseEntity.ok(qrTicketService.issueMember(dto));
   }

--- a/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
+++ b/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
@@ -1,7 +1,13 @@
 package com.fairing.fairplay.qr.controller;
 
 
+import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
+import com.fairing.fairplay.qr.dto.QrTicketResponseDto;
+import com.fairing.fairplay.qr.service.QrTicketService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,5 +16,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/qr-tickets")
 public class QrTicketController {
 
+  private final QrTicketService qrTicketService;
+
+  // 마이페이지에서 QR 티켓 조회
+  @GetMapping
+  public ResponseEntity<QrTicketResponseDto> issueMember(@RequestBody QrTicketRequestDto dto) {
+    return ResponseEntity.ok(qrTicketService.issueMember(dto));
+  }
+
+  // 비회원 QR 티켓 조회 (참석자)
+
+  // QR 티켓 만료
+
+  // QR 티켓 재발급
+
+  // QR 티켓 삭제?
 
 }

--- a/src/main/java/com/fairing/fairplay/qr/dto/QrTicketResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/qr/dto/QrTicketResponseDto.java
@@ -1,5 +1,44 @@
 package com.fairing.fairplay.qr.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class QrTicketResponseDto {
 
+  private String title; // 행사명
+  private String buildingName; //행사 장소
+  private String qrCode; // qr이미지 코드
+  private String manualCode; // 수동 코드
+  private String ticketNo; // 티켓 번호
+  private ViewingScheduleInfo viewingScheduleInfo; // 관람 일시 정보
+  private String reservationDate; // 예매일
+
+  public QrTicketResponseDto(String title, String buildingName,
+      String ticketNo, String qrCode, String manualCode) {
+    this.title = title;
+    this.buildingName = buildingName;
+    this.ticketNo = ticketNo;
+    this.qrCode = qrCode;
+    this.manualCode = manualCode;
+  }
+
+  // 관람 일시 정보
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class ViewingScheduleInfo {
+
+    private String date; // 날짜
+    private String dayOfWeek; // 요일
+    private String startTime; // 시작 시간
+  }
 }

--- a/src/main/java/com/fairing/fairplay/qr/dto/QrTicketResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/qr/dto/QrTicketResponseDto.java
@@ -21,6 +21,11 @@ public class QrTicketResponseDto {
   private ViewingScheduleInfo viewingScheduleInfo; // 관람 일시 정보
   private String reservationDate; // 예매일
 
+  /**
+   * QueryDSL JPQL 프로젝션용 생성자
+   *
+   * @see com.fairing.fairplay.qr.repository.QrTicketRepository#findDtoById(Long)
+   */
   public QrTicketResponseDto(String title, String buildingName,
       String ticketNo, String qrCode, String manualCode) {
     this.title = title;

--- a/src/main/java/com/fairing/fairplay/qr/entity/QrTicket.java
+++ b/src/main/java/com/fairing/fairplay/qr/entity/QrTicket.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
-/*QR티켓*/
+/*QR 티켓*/
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
@@ -66,4 +66,7 @@ public class QrTicket {
 
   @Column(name = "manual_code", nullable = true, unique = true, length = 15)
   private String manualCode;
+
+  @Column(name = "ticket_no", nullable = false, unique = true, length = 30)
+  private String ticketNo;
 }

--- a/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
@@ -1,11 +1,30 @@
 package com.fairing.fairplay.qr.repository;
 
 import com.fairing.fairplay.attendee.entity.Attendee;
+import com.fairing.fairplay.qr.dto.QrTicketResponseDto;
 import com.fairing.fairplay.qr.entity.QrTicket;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface QrTicketRepository extends JpaRepository<QrTicket, Long> {
+
+  @Query("""
+          SELECT new com.fairing.fairplay.qr.dto.QrTicketResponseDto(
+            e.titleKr,
+            l.buildingName,
+            q.ticketNo,
+            q.qrCode,
+            q.manualCode)
+        FROM QrTicket q
+        JOIN q.eventTicket et
+        JOIN et.event e
+        JOIN e.eventDetail ed
+        JOIN ed.location l
+        WHERE q.id = :qrTicketId
+      """)
+  Optional<QrTicketResponseDto> findDtoById(@Param("qrTicketId") Long qrTicketId);
 
   Optional<QrTicket> findByAttendee(Attendee attendee);
 }

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
@@ -1,0 +1,54 @@
+package com.fairing.fairplay.qr.service;
+
+import com.fairing.fairplay.attendee.entity.QAttendee;
+import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
+import com.fairing.fairplay.qr.util.QrLinkTokenGenerator;
+import com.fairing.fairplay.reservation.entity.QReservation;
+import com.fairing.fairplay.reservation.repository.ReservationRepositoryCustom;
+import com.fairing.fairplay.ticket.entity.QEventSchedule;
+import com.querydsl.core.Tuple;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+// QR티켓 스케줄러 관련 서비스
+@Service
+@RequiredArgsConstructor
+public class QrTicketBatchService {
+
+  private final QrLinkTokenGenerator qrLinkTokenGenerator;
+  private final QrTicketLinkSender qrTicketLinkSender;
+  private final ReservationRepositoryCustom reservationRepositoryCustom;
+
+  // 행사 1일 남은 예약건 조회
+  public List<Tuple> fetchQrTicketBatch() {
+    return reservationRepositoryCustom.findReservationsOneDayBeforeEventWithoutRepresentatives();
+  }
+
+  // 비회원 QR 티켓 링크 발급 -> 스케쥴러가 실행. 오전9시 실행 batch 도입 예정
+  public void generateQrLink(List<Tuple> reservations) {
+    for (Tuple tuple : reservations) {
+      QReservation reservation = QReservation.reservation;
+      QAttendee attendee = QAttendee.attendee;
+      QEventSchedule schedule = QEventSchedule.eventSchedule;
+
+      Long reservationId = tuple.get(reservation.reservationId);
+      Long ticketId = tuple.get(reservation.ticket.ticketId);
+      Long attendeeId = tuple.get(attendee.id);
+      String attendeeName = tuple.get(attendee.name);
+      String attendeeEmail = tuple.get(attendee.email);
+      Long eventId = tuple.get(schedule.event.eventId);
+
+      QrTicketRequestDto dto = QrTicketRequestDto.builder()
+          .attendeeId(attendeeId)
+          .reservationId(reservationId)
+          .eventId(eventId)
+          .ticketId(ticketId)
+          .build();
+
+      String token = qrLinkTokenGenerator.generateToken(dto);
+      String qrUrl = "https://your-site.com/qr-tickets/" + token; // 수정 예정
+      qrTicketLinkSender.sendQrTicket(attendeeName, attendeeEmail, qrUrl);
+    }
+  }
+}

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
@@ -27,11 +27,11 @@ public class QrTicketBatchService {
 
   // 비회원 QR 티켓 링크 발급 -> 스케쥴러가 실행. 오전9시 실행 batch 도입 예정
   public void generateQrLink(List<Tuple> reservations) {
-    for (Tuple tuple : reservations) {
-      QReservation reservation = QReservation.reservation;
-      QAttendee attendee = QAttendee.attendee;
-      QEventSchedule schedule = QEventSchedule.eventSchedule;
+    QReservation reservation = QReservation.reservation;
+    QAttendee attendee = QAttendee.attendee;
+    QEventSchedule schedule = QEventSchedule.eventSchedule;
 
+    for (Tuple tuple : reservations) {
       Long reservationId = tuple.get(reservation.reservationId);
       Long ticketId = tuple.get(reservation.ticket.ticketId);
       Long attendeeId = tuple.get(attendee.id);
@@ -39,16 +39,19 @@ public class QrTicketBatchService {
       String attendeeEmail = tuple.get(attendee.email);
       Long eventId = tuple.get(schedule.event.eventId);
 
-      QrTicketRequestDto dto = QrTicketRequestDto.builder()
-          .attendeeId(attendeeId)
-          .reservationId(reservationId)
-          .eventId(eventId)
-          .ticketId(ticketId)
-          .build();
-
-      String token = qrLinkTokenGenerator.generateToken(dto);
-      String qrUrl = "https://your-site.com/qr-tickets/" + token; // 수정 예정
-      qrTicketLinkSender.sendQrTicket(attendeeName, attendeeEmail, qrUrl);
+      try {
+        QrTicketRequestDto dto = QrTicketRequestDto.builder()
+            .attendeeId(attendeeId)
+            .reservationId(reservationId)
+            .eventId(eventId)
+            .ticketId(ticketId)
+            .build();
+        String token = qrLinkTokenGenerator.generateToken(dto);
+        String qrUrl = "https://your-site.com/qr-tickets/" + token; // 수정 예정
+        qrTicketLinkSender.sendQrTicket(attendeeName, attendeeEmail, qrUrl);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 }

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketInitProvider.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketInitProvider.java
@@ -1,21 +1,42 @@
 package com.fairing.fairplay.qr.service;
 
 import com.fairing.fairplay.attendee.entity.Attendee;
+import com.fairing.fairplay.attendee.entity.QAttendee;
 import com.fairing.fairplay.attendee.repository.AttendeeRepository;
 import com.fairing.fairplay.common.exception.CustomException;
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.event.entity.QEvent;
+import com.fairing.fairplay.event.entity.QEventDetail;
 import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
 import com.fairing.fairplay.qr.entity.QrTicket;
 import com.fairing.fairplay.qr.repository.QrTicketRepository;
+import com.fairing.fairplay.qr.util.CodeGenerator;
+import com.fairing.fairplay.reservation.entity.QReservation;
+import com.fairing.fairplay.ticket.entity.EventTicket;
+import com.fairing.fairplay.ticket.entity.QEventSchedule;
+import com.fairing.fairplay.ticket.entity.QTicket;
+import com.fairing.fairplay.ticket.entity.Ticket;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
+/*
+ * QR 티켓 객체 생성 클래스
+ * */
 @Component
 @RequiredArgsConstructor
 public class QrTicketInitProvider {
 
   private final AttendeeRepository attendeeRepository;
   private final QrTicketRepository qrTicketRepository;
+  private final JPAQueryFactory queryFactory;
+  private final CodeGenerator codeGenerator;
 
   public QrTicket load(QrTicketRequestDto dto, Integer attendeeTypeCodeId) {
     Attendee attendee;
@@ -48,7 +69,6 @@ public class QrTicketInitProvider {
    * 다음날 열리는 행사에 참석 예정인 모든 사람을 조회해
    * 각 참석자에 대한 QR티켓을 발급 ( QR코드는 생성 안함 )
    * */
-  /*
   public List<QrTicket> scheduleCreateQrTicket() {
 
     // 현재 날짜 기준 다음날 시작하는 행사 데이터 추출
@@ -62,7 +82,7 @@ public class QrTicketInitProvider {
     QTicket ticket = QTicket.ticket;
 
     // 참석자 정보, 이벤트 정보, 티켓 정보, 재입장 허용 여부, 스케줄 날짜+종료시간
-    List<Tuple> result = queryFactory
+    List<Tuple> results = queryFactory
         .select(attendee,
             event,
             ticket,
@@ -71,13 +91,13 @@ public class QrTicketInitProvider {
             eventSchedule.endTime)
         .from(attendee)
         .join(attendee.reservation, reservation)
-        .join(reservation.eventSchedule, eventSchedule)
+        .join(reservation.schedule, eventSchedule)
         .join(eventSchedule.event, event)
         .join(event.eventDetail, eventDetail)
         .where(eventDetail.startDate.eq(targetDate))
-        .fetchJoin();
+        .fetch();
 
-    List<QrTicket> qrTickets = result.stream()
+    return results.stream()
         .map(tuple -> {
           Attendee a = tuple.get(attendee);
           Event e = tuple.get(event);
@@ -85,8 +105,10 @@ public class QrTicketInitProvider {
           Boolean reentryAllowed = tuple.get(eventDetail.reentryAllowed);
           LocalDate date = tuple.get(eventSchedule.date);
           LocalTime endTime = tuple.get(eventSchedule.endTime);
+          String eventCode = tuple.get(event.eventCode);
 
-          LocalDateTime expiredAt = LocalDateTime.of(date, endTime);
+          LocalDateTime expiredAt = LocalDateTime.of(date, endTime); //만료시간 설정
+          String ticketNo = codeGenerator.generateTicketNo(eventCode); // 티켓번호 설정
 
           return QrTicket.builder()
               .attendee(a)
@@ -95,13 +117,11 @@ public class QrTicketInitProvider {
               .expiredAt(expiredAt)
               .issuedAt(LocalDateTime.now())
               .active(true)
+              .ticketNo(ticketNo)
               .qrCode(null)
               .manualCode(null)
               .build();
         })
         .toList();
-
-    return qrTickets;
   }
-   */
 }

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketLinkSender.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketLinkSender.java
@@ -1,0 +1,182 @@
+package com.fairing.fairplay.qr.service;
+
+import com.fairing.fairplay.core.util.EmailSender;
+import com.fairing.fairplay.qr.util.QrLinkTokenGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/*
+ * QR 티켓 전송 클래스
+ * */
+@Component
+@RequiredArgsConstructor
+public class QrTicketLinkSender {
+
+  private final QrLinkTokenGenerator qrLinkTokenGenerator;
+  private final EmailSender emailSender;
+
+  public void sendQrTicket(String name, String email, String qrUrl) {
+
+
+    String content = """
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FairPlay QR 티켓</title>
+    <style>
+      body {
+        font-family: "Segoe UI", "Apple SD Gothic Neo", Arial, sans-serif;
+        background: #f1f5f9;
+        margin: 0;
+        padding: 20px;
+      }
+      .container {
+        max-width: 400px;
+        margin: 0 auto;
+        border: 1px solid #e2e8f0;
+        border-radius: 16px;
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
+        padding: 40px 24px 32px 24px;
+        background: #ffffff;
+      }
+      .logo {
+        text-align: center;
+        margin-bottom: 24px;
+      }
+      .logo-icon {
+        width: 64px;
+        height: 64px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 16px;
+      }
+      h2 {
+        color: #1f2937;
+        text-align: center;
+        font-size: 24px;
+        font-weight: 600;
+        margin: 0;
+      }
+      .brand {
+        color: #3b82f6;
+        font-weight: 700;
+      }
+      .message-box {
+        margin: 24px 0;
+        padding: 20px;
+        border-radius: 12px;
+        background: linear-gradient(135deg, #f8fafc, #f1f5f9);
+        border: 1px solid #e2e8f0;
+      }
+      .message-box p {
+        font-size: 15px;
+        color: #475569;
+        text-align: center;
+        margin: 0;
+        line-height: 1.6;
+      }
+      .qr-link-box {
+        text-align: center;
+        margin: 24px 0;
+      }
+      .qr-link-button {
+        background-color: #3b82f6;
+        color: #ffffff;
+        padding: 16px 24px;
+        border: none;
+        border-radius: 8px;
+        font-size: 16px;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-block;
+        margin-top: 12px;
+      }
+      .warning-box {
+        background: #fef2f2;
+        border: 1px solid #fecaca;
+        border-radius: 8px;
+        padding: 16px;
+        margin: 20px 0;
+      }
+      .warning-box ul {
+        font-size: 13px;
+        color: #4b5563;
+        margin: 0;
+        line-height: 1.5;
+        padding-left: 20px;
+      }
+      .warning-box li {
+        margin-bottom: 6px;
+      }
+      .warning-highlight {
+        color: #dc2626;
+      }
+      .contact-link {
+        color: #3b82f6;
+        text-decoration: none;
+        font-weight: 500;
+      }
+      .footer {
+        margin-top: 32px;
+        text-align: center;
+        padding-top: 20px;
+        border-top: 1px solid #f1f5f9;
+      }
+      .footer span {
+        font-size: 12px;
+        color: #9ca3af;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="logo">
+        <div class="logo-icon">
+          <img
+            src="cid:logo"
+            alt="FairPlay Logo"
+            style="width: 64px; height: 64px; object-fit: contain"
+          />
+        </div>
+        <h2><span class="brand">FairPlay</span> QR 티켓 도착</h2>
+      </div>
+
+      <div class="message-box">
+        <p>
+          안녕하세요 <strong class="brand">%s님!</strong><br />
+          <strong class="brand">FairPlay</strong>에서 예약하신<br />
+          티켓의 <strong class="highlight">QR 링크</strong>가 발급되었습니다.<br />
+          아래 버튼을 눌러 QR 티켓을 확인해 주세요.
+        </p>
+      </div>
+
+      <div class="qr-link-box">
+        <a href="%s" class="qr-link-button" target="_blank">QR 티켓 확인하기</a>
+      </div>
+
+      <div class="warning-box">
+        <ul>
+          <li>🎟 <strong>QR 티켓은 행사 입장 시 필요합니다</strong></li>
+          <li>🔒 <strong>타인에게 링크를 공유하지 마세요</strong></li>
+          <li>
+            📞 문의:
+            <a href="mailto:support@fair-play.ink" class="contact-link"
+              >support@fair-play.ink</a
+            >
+          </li>
+        </ul>
+      </div>
+
+      <div class="footer">
+        <span>© 2025 FairPlay</span>
+      </div>
+    </div>
+  </body>
+</html>
+""".formatted(name,qrUrl);
+    emailSender.send(email, "[FairPlay] QR 티켓", content, "logo", "etc/logo.png");
+  }
+}

--- a/src/main/java/com/fairing/fairplay/qr/util/CodeGenerator.java
+++ b/src/main/java/com/fairing/fairplay/qr/util/CodeGenerator.java
@@ -1,21 +1,30 @@
 package com.fairing.fairplay.qr.util;
 
 import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class CodeGenerator {
 
   private static final String CHAR_POOL = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // 헷갈리는 문자 제외
   private static final int CODE_LENGTH = 8;
 
   private static final SecureRandom random = new SecureRandom();
+  private final RedisTemplate<Object, Object> redisTemplate;
 
+  // QR 코드 생성 ex. 550e8400-e29b-41d4-a716-446655440000
   public String generateRandomToken() {
     return UUID.randomUUID().toString().replace("-", "");
   }
 
+  // 수동 코드 생성 ex. ABCD-EFGH
   public String generateManualCode() {
     StringBuilder sb = new StringBuilder(CODE_LENGTH + 1); // '-' 하나 추가
 
@@ -29,5 +38,17 @@ public class CodeGenerator {
       }
     }
     return sb.toString();
+  }
+
+  // 티켓 코드 생성 ex. FR2025-20250802-0012
+  public String generateTicketNo(String eventCode) {
+    String date = LocalDateTime.now().format(DateTimeFormatter.BASIC_ISO_DATE); // "20250802"
+    String key = "ticketSeq:" + eventCode + ":" + date;
+    Long seq = redisTemplate.opsForValue().increment(key); // redis에서 자동 증가
+    if (seq == 1) {
+      redisTemplate.expire(key, Duration.ofDays(1)); // 하루 단위로 시퀀스 초기화
+    }
+
+    return String.format("%s-%s-%04d", eventCode, date, seq);
   }
 }

--- a/src/main/java/com/fairing/fairplay/qr/util/QrLinkTokenGenerator.java
+++ b/src/main/java/com/fairing/fairplay/qr/util/QrLinkTokenGenerator.java
@@ -30,18 +30,30 @@ public class QrLinkTokenGenerator {
 
   // 암호화된 문자열을 DTO 객체로 만듦
   public QrTicketRequestDto decodeToDto(String token) {
-    long[] numbers = decodeToken(token);
-    // 디코딩 결과 배열 길이 체크
-    if (numbers.length < 4) {
-      throw new IllegalArgumentException("Invalid token format");
+    if(token == null || token.trim().isEmpty()) {
+      throw new IllegalArgumentException("QR 링크 토큰이 비어 있습니다.");
     }
 
-    return QrTicketRequestDto.builder()
-        .reservationId(numbers[0] == 0 ? null : numbers[0])
-        .attendeeId(numbers[1] == 0 ? null : numbers[1])
-        .eventId(numbers[2] == 0 ? null : numbers[2])
-        .ticketId(numbers[3] == 0 ? null : numbers[3])
-        .build();
+    try{
+      long[] numbers = decodeToken(token);
+      // 디코딩 결과 배열 길이 체크
+      if (numbers.length < 4) {
+        throw new IllegalArgumentException("유효하지 않은 QR 토큰 형식입니다.");
+      }
+
+      if(numbers[0] == 0 && numbers[1] == 0 && numbers[2] == 0 && numbers[3] == 0){
+        throw new IllegalArgumentException("유효하지 않은 QR 토큰 데이터입니다.");
+      }
+
+      return QrTicketRequestDto.builder()
+          .reservationId(numbers[0] == 0 ? null : numbers[0])
+          .attendeeId(numbers[1] == 0 ? null : numbers[1])
+          .eventId(numbers[2] == 0 ? null : numbers[2])
+          .ticketId(numbers[3] == 0 ? null : numbers[3])
+          .build();
+    }catch(Exception e){
+      throw new IllegalArgumentException("토큰 디코딩 중 오류가 발생했습니다: " + e.getMessage(), e);
+    }
   }
 
   // 토큰 문자열 -> long[]으로 변환

--- a/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepositoryCustom.java
@@ -1,0 +1,45 @@
+package com.fairing.fairplay.reservation.repository;
+
+import com.fairing.fairplay.attendee.entity.QAttendee;
+import com.fairing.fairplay.reservation.entity.QReservation;
+import com.fairing.fairplay.ticket.entity.QEventSchedule;
+import com.fairing.fairplay.ticket.entity.QScheduleTicket;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  // 행사 하루 전 예약건의 참석자 중 대표자가 아닌 사용자 조회
+  public List<Tuple> findReservationsOneDayBeforeEventWithoutRepresentatives() {
+    LocalDate tomorrow = LocalDate.now().plusDays(1);
+
+    QReservation reservation = QReservation.reservation;
+    QEventSchedule schedule = QEventSchedule.eventSchedule;
+    QScheduleTicket scheduleTicket = QScheduleTicket.scheduleTicket;
+    QAttendee attendee = QAttendee.attendee;
+
+    return queryFactory
+        .select(reservation.reservationId, reservation.ticket.ticketId, attendee.id, attendee.name, attendee.email,
+            schedule.event.eventId)
+        .from(reservation)
+        .join(schedule).on(reservation.schedule.scheduleId.eq(schedule.scheduleId))
+        .join(scheduleTicket).on(schedule.scheduleId.eq(scheduleTicket.id.scheduleId)
+            .and(reservation.ticket.ticketId.eq(scheduleTicket.id.ticketId)))
+        .join(attendee).on(attendee.reservation.eq(reservation)
+            .and(attendee.attendeeTypeCode.code.eq("GUEST")))  // 대표자 아님
+        .where(
+            schedule.date.eq(tomorrow),
+            reservation.canceled.isFalse(),
+            reservation.reservationStatusCode.code.eq("CONFIRMED") // 예시
+        )
+        .fetch();
+  }
+}

--- a/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepositoryCustom.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ReservationRepositoryCustom {
 
+  public static final String ATTENDEE_TYPE_GUEST = "GUEST";
+  public static final String RESERVATION_STATUS_CONFIRMED = "CONFIRMED";
   private final JPAQueryFactory queryFactory;
 
   // 행사 하루 전 예약건의 참석자 중 대표자가 아닌 사용자 조회
@@ -27,18 +29,19 @@ public class ReservationRepositoryCustom {
     QAttendee attendee = QAttendee.attendee;
 
     return queryFactory
-        .select(reservation.reservationId, reservation.ticket.ticketId, attendee.id, attendee.name, attendee.email,
+        .select(reservation.reservationId, reservation.ticket.ticketId, attendee.id, attendee.name,
+            attendee.email,
             schedule.event.eventId)
         .from(reservation)
         .join(schedule).on(reservation.schedule.scheduleId.eq(schedule.scheduleId))
         .join(scheduleTicket).on(schedule.scheduleId.eq(scheduleTicket.id.scheduleId)
             .and(reservation.ticket.ticketId.eq(scheduleTicket.id.ticketId)))
         .join(attendee).on(attendee.reservation.eq(reservation)
-            .and(attendee.attendeeTypeCode.code.eq("GUEST")))  // 대표자 아님
+            .and(attendee.attendeeTypeCode.code.eq(ATTENDEE_TYPE_GUEST)))
         .where(
             schedule.date.eq(tomorrow),
             reservation.canceled.isFalse(),
-            reservation.reservationStatusCode.code.eq("CONFIRMED") // 예시
+            reservation.reservationStatusCode.code.eq(RESERVATION_STATUS_CONFIRMED)
         )
         .fetch();
   }

--- a/src/main/java/com/fairing/fairplay/scheduler/QrTicketScheduler.java
+++ b/src/main/java/com/fairing/fairplay/scheduler/QrTicketScheduler.java
@@ -1,6 +1,7 @@
 package com.fairing.fairplay.scheduler;
 
-import com.fairing.fairplay.qr.service.QrTicketService;
+
+import com.fairing.fairplay.qr.service.QrTicketBatchService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -8,11 +9,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class QrTicketScheduler {
 
-  private final QrTicketService qrTicketService;
+  private final QrTicketBatchService qrTicketBatchService;
 
 //  // 매일 오전 9시 티켓 전송
 //  @Scheduled(cron = "0 0 09 * * *")
 //  public void runSendQrTicket(){
-//    qrTicketService.generateQrLink();
+//    List<Tuple> batch = qrTicketBatchService.fetchQrTicketBatch();
+//    qrTicketBatchService.generateQrLink(batch);
 //  }
 }


### PR DESCRIPTION
## 변경 사항
- QR 티켓 링크 토큰 발급 방식을 JWT에서 hashids 방식으로 변경
- QR 티켓 발급, 이메일 전송관련 서비스 클래스 분리
- 회원 QR 티켓 조회 구현

## 추가 사항
- QR 티켓 조회 링크(qrUrl)은 추후 변경 예정

## 관련 이슈
#36  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * QR 티켓 발급 및 조회를 위한 새로운 API 엔드포인트가 추가되었습니다.
  * QR 티켓 일괄 발급 및 이메일 발송 기능이 도입되었습니다.
  * QR 티켓 응답에 행사명, 건물명, QR 코드, 수기 코드, 티켓 번호, 예약일, 관람 일정 정보가 포함됩니다.
  * QR 티켓 번호가 이벤트별로 일자·순번 조합으로 생성되어 고유성을 보장합니다.
  * QR 티켓 링크를 이메일로 발송하는 기능이 추가되었습니다.

* **버그 수정**
  * 예약 검증 및 예외처리가 강화되어 잘못된 요청 시 오류 메시지가 제공됩니다.

* **리팩터링**
  * QR 티켓 토큰 생성 방식이 JWT에서 Hashids 기반으로 변경되었습니다.
  * 일부 서비스 및 스케줄러 의존성이 개선되었습니다.

* **기타**
  * 예약/티켓 관련 데이터 조회 및 배치 처리 로직이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->