### PR TITLE
refactor: 참석자, 폼링크 관련 응답, 예외 추가

### DIFF
--- a/src/main/java/com/fairing/fairplay/attendee/controller/AttendeeController.java
+++ b/src/main/java/com/fairing/fairplay/attendee/controller/AttendeeController.java
@@ -7,7 +7,7 @@ import com.fairing.fairplay.attendee.dto.AttendeeUpdateRequestDto;
 import com.fairing.fairplay.attendee.service.AttendeeService;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,7 +22,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/attendees")
-@Slf4j
 public class AttendeeController {
 
   private final AttendeeService attendeeService;
@@ -31,7 +30,6 @@ public class AttendeeController {
   @PostMapping
   public ResponseEntity<AttendeeInfoResponseDto> saveAttendee(@RequestParam String token,
       @RequestBody AttendeeSaveRequestDto dto) {
-    log.info("attendee save request: {}", token);
     return ResponseEntity.status(HttpStatus.CREATED).body(attendeeService.saveGuest(token, dto));
   }
 

--- a/src/main/java/com/fairing/fairplay/attendee/controller/AttendeeController.java
+++ b/src/main/java/com/fairing/fairplay/attendee/controller/AttendeeController.java
@@ -1,11 +1,13 @@
 package com.fairing.fairplay.attendee.controller;
 
 import com.fairing.fairplay.attendee.dto.AttendeeInfoResponseDto;
+import com.fairing.fairplay.attendee.dto.AttendeeListInfoResponseDto;
 import com.fairing.fairplay.attendee.dto.AttendeeSaveRequestDto;
 import com.fairing.fairplay.attendee.dto.AttendeeUpdateRequestDto;
 import com.fairing.fairplay.attendee.service.AttendeeService;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/attendees")
+@Slf4j
 public class AttendeeController {
 
   private final AttendeeService attendeeService;
@@ -28,12 +31,13 @@ public class AttendeeController {
   @PostMapping
   public ResponseEntity<AttendeeInfoResponseDto> saveAttendee(@RequestParam String token,
       @RequestBody AttendeeSaveRequestDto dto) {
+    log.info("attendee save request: {}", token);
     return ResponseEntity.status(HttpStatus.CREATED).body(attendeeService.saveGuest(token, dto));
   }
 
   // 참석자 전체 조회 -> 단체 예약일 경우에만 접근 가능. authenticationprincipal 추가 필요
   @GetMapping("/{reservationId}")
-  public ResponseEntity<List<AttendeeInfoResponseDto>> findAll(@PathVariable Long reservationId) {
+  public ResponseEntity<AttendeeListInfoResponseDto> findAll(@PathVariable Long reservationId) {
     return ResponseEntity.status(HttpStatus.OK).body(attendeeService.findAll(reservationId));
   }
 

--- a/src/main/java/com/fairing/fairplay/attendee/dto/AttendeeInfoResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/attendee/dto/AttendeeInfoResponseDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+// 참석자 개별
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/fairing/fairplay/attendee/dto/AttendeeListInfoResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/attendee/dto/AttendeeListInfoResponseDto.java
@@ -1,19 +1,17 @@
 package com.fairing.fairplay.attendee.dto;
 
-import java.time.LocalDate;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+// 참석자 리스트
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class AttendeeSaveRequestDto {
-
-  private String name;
-  private String email;
-  private String phone;
-  private LocalDate birth;
+public class AttendeeListInfoResponseDto {
+  private Long reservationId;
+  private List<AttendeeInfoResponseDto> attendees;
 }

--- a/src/main/java/com/fairing/fairplay/attendee/entity/Attendee.java
+++ b/src/main/java/com/fairing/fairplay/attendee/entity/Attendee.java
@@ -49,6 +49,7 @@ public class Attendee {
   private LocalDate birth;
   @Column(name = "checked_in", nullable = false)
   @ColumnDefault("false")
+  @Builder.Default
   private Boolean checkedIn = false;
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "attendee_type_code_id")

--- a/src/main/java/com/fairing/fairplay/attendee/repository/AttendeeRepository.java
+++ b/src/main/java/com/fairing/fairplay/attendee/repository/AttendeeRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AttendeeRepository extends JpaRepository<Attendee, Long> {
 
-  List<Attendee> findAllByReservation_ReservationId(Long reservationId);
+  List<Attendee> findAllByReservation_ReservationIdOrderByIdAsc(Long reservationId);
 
   Optional<Attendee> findByReservation_ReservationIdAndAttendeeTypeCode_Id(Long reservationId,
       Integer attendeeTypeCodeId);

--- a/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
+++ b/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
@@ -69,11 +69,21 @@ public class AttendeeService {
   // 동반자 정보 수정
   @Transactional
   public AttendeeInfoResponseDto updateAttendee(Long attendeeId, AttendeeUpdateRequestDto dto) {
+    // 정보 요청한 회원의 attendeeType 조회 후 primary가 아닐 경우 exception 설정 추후 추가
+
+    // 예약 있는지 조회
+    checkReservation(dto.getReservationId());
+
+    // 참석자 정보 조회
     Attendee attendee = attendeeRepository.findById(attendeeId)
         .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "참석자 정보를 조회할 수 없습니다."));
 
-    checkReservation(dto.getReservationId());
+    // 수정하려는 정보가 대표자일 경우 수정 불가하므로 예외 발생
+    if(attendee.getAttendeeTypeCode().getCode().trim().equals("PRIMARY")) {
+      throw new CustomException(HttpStatus.FORBIDDEN,"대표자 정보는 수정할 수 없습니다.");
+    }
 
+    // 정보 변경
     attendee.setEmail(dto.getEmail());
     attendee.setPhone(dto.getPhone());
     attendee.setName(dto.getName());

--- a/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
+++ b/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
@@ -79,7 +79,7 @@ public class AttendeeService {
         .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "참석자 정보를 조회할 수 없습니다."));
 
     // 수정하려는 정보가 대표자일 경우 수정 불가하므로 예외 발생
-    if(attendee.getAttendeeTypeCode().getCode().trim().equals("PRIMARY")) {
+    if("PRIMARY".equals(attendee.getAttendeeTypeCode().getCode().trim())) {
       throw new CustomException(HttpStatus.FORBIDDEN,"대표자 정보는 수정할 수 없습니다.");
     }
 

--- a/src/main/java/com/fairing/fairplay/shareticket/dto/ShareTicketSaveRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/dto/ShareTicketSaveRequestDto.java
@@ -1,14 +1,18 @@
 package com.fairing.fairplay.shareticket.dto;
 
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ShareTicketSaveRequestDto {
 
   private Long reservationId;
-  private int totalAllowed;
+  private Integer totalAllowed;
   private LocalDateTime expiredAt;
 }

--- a/src/main/java/com/fairing/fairplay/shareticket/repository/ShareTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/repository/ShareTicketRepository.java
@@ -15,4 +15,5 @@ public interface ShareTicketRepository extends JpaRepository<ShareTicket, Long> 
       Pageable pageable);
 
   boolean existsByLinkToken(String token);
+  boolean existsByReservation_ReservationId(Long reservationId);
 }

--- a/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketService.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketService.java
@@ -51,9 +51,9 @@ public class ShareTicketService {
 
     ShareTicket shareTicket = ShareTicket.builder()
         .linkToken(token)
-        .totalAllowed(dto.getTotalAllowed())
+        .totalAllowed(dto.getTotalAllowed()-1) //대표자 제출 O
         .expired(false)
-        .submittedCount(0)
+        .submittedCount(1) // 대표자 제출
         .reservation(reservation)
         .expiredAt(dto.getExpiredAt())
         .build();

--- a/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketService.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketService.java
@@ -57,9 +57,13 @@ public class ShareTicketService {
           .encodeToString(bytes); //5B3Ej0AdRMqrqY7xV6k9tw 형태
     } while (shareTicketRepository.existsByLinkToken(token));
 
+    if (dto.getTotalAllowed() == null || dto.getTotalAllowed() <= 0) {
+      throw new IllegalArgumentException("허용 인원은 1명 이상이어야 합니다.");
+    }
+
     ShareTicket shareTicket = ShareTicket.builder()
         .linkToken(token)
-        .totalAllowed(dto.getTotalAllowed() - 1) //대표자 제출 O
+        .totalAllowed(dto.getTotalAllowed()) //대표자 제출 O
         .expired(false)
         .submittedCount(1) // 대표자 제출
         .reservation(reservation)

--- a/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketService.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketService.java
@@ -1,5 +1,6 @@
 package com.fairing.fairplay.shareticket.service;
 
+import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.common.exception.LinkExpiredException;
 import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.reservation.repository.ReservationRepository;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +37,15 @@ public class ShareTicketService {
       throw new IllegalArgumentException("유효하지 않은 요청입니다.");
     }
 
+    // 예약 유무 조회
+    Reservation reservation = reservationRepository.findById(dto.getReservationId())
+        .orElseThrow(() -> new EntityNotFoundException("예약을 찾을 수 없습니다."));
+
+    // 예약 ID 기준 폼이 생성되어있는지 조회
+    if (shareTicketRepository.existsByReservation_ReservationId(dto.getReservationId())) {
+      throw new CustomException(HttpStatus.CONFLICT, "이미 폼 링크가 생성되었습니다.");
+    }
+
     String token;
     do {
       UUID uuid = UUID.randomUUID();
@@ -46,12 +57,9 @@ public class ShareTicketService {
           .encodeToString(bytes); //5B3Ej0AdRMqrqY7xV6k9tw 형태
     } while (shareTicketRepository.existsByLinkToken(token));
 
-    Reservation reservation = reservationRepository.findById(dto.getReservationId())
-        .orElseThrow(() -> new EntityNotFoundException("예약을 찾을 수 없습니다."));
-
     ShareTicket shareTicket = ShareTicket.builder()
         .linkToken(token)
-        .totalAllowed(dto.getTotalAllowed()-1) //대표자 제출 O
+        .totalAllowed(dto.getTotalAllowed() - 1) //대표자 제출 O
         .expired(false)
         .submittedCount(1) // 대표자 제출
         .reservation(reservation)


### PR DESCRIPTION
## 변경 사항
- 폼링크 생성 시 대표자 제출 고려해 제출 횟수 1 증가
- 한 개의 예약 ID에 대한 폼링크 중복 생성 오류 수정
- 참석자 저장, 전체 조회 응답 변경
- 참석자 정보 수정 관련 예외 추가 

## 추가 사항
- 정보 요청한 회원의 attendeeType 조회 후 primary가 아닐 경우 exception 설정 추후 추가 

## 관련 이슈
#36 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 예약 ID로 공유 티켓 폼 존재 여부를 확인하는 기능이 추가되었습니다.

* **버그 수정**
  * 참석자 목록 조회 시 예약 ID와 함께 반환되며, 참석자 정보가 오름차순 정렬로 제공됩니다.
  * 대표자 제출 시 공유 티켓의 제출 카운트가 즉시 반영되고, 중복 폼 생성을 방지합니다.
  * 참석자 업데이트 시 대표자 타입 변경이 제한됩니다.

* **개선 사항**
  * 참석자 저장 요청 시 불필요한 필드가 제거되었습니다.
  * 일부 DTO에 생성자 및 빌더 패턴 지원이 추가되었습니다.
  * 참석자 정보 응답 구조가 개선되었습니다.
  * 서비스 메서드들이 명확한 파라미터를 받도록 변경되었습니다.

* **스타일**
  * 코드 주석 및 정렬 개선이 이루어졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->