### PR TITLE
feat: QR 티켓 관련 재발급 구현

### DIFF
--- a/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
+++ b/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
@@ -1,6 +1,8 @@
 package com.fairing.fairplay.qr.controller;
 
 
+import com.fairing.fairplay.qr.dto.QrTicketReissueRequestDto;
+import com.fairing.fairplay.qr.dto.QrTicketReissueResponseDto;
 import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
 import com.fairing.fairplay.qr.dto.QrTicketResponseDto;
 import com.fairing.fairplay.qr.dto.QrTicketUpdateRequestDto;
@@ -34,11 +36,36 @@ public class QrTicketController {
     return ResponseEntity.ok(qrTicketService.issueGuest(token));
   }
 
-  // QR 티켓 재발급
+  // 1. QR 티켓 재발급 - QR 티켓 조회 시 이미지코드와 수동 코드만 재발급(새로고침버튼)
   @PostMapping("/reissue")
   public ResponseEntity<QrTicketUpdateResponseDto> reissueQrTicket(
       @RequestBody QrTicketUpdateRequestDto dto) {
     return ResponseEntity.ok(qrTicketService.reissueQrTicket(dto));
+  }
+
+  // 2. QR 티켓 재발급 - 회원이 QR 티켓 분실 시 회원이 티켓 자체 재발급 요청
+  /*
+  * 마이 페이지 접근 가능한 경우
+  * 1. "관리자 문의"
+  * 2. 관리자 승인 후 발급
+  * 3. 이메일로 발급 완료 메일 전송
+  * */
+//  @PostMapping("/admin/reissue")
+//  public ResponseEntity<QrTicketReissueResponseDto> requestReissueQrTicket(@RequestBody QrTicketRequestDto dto) {
+//    return ResponseEntity.ok(qrTicketService.reissueAdminQrTicket());
+//  }
+
+
+  // 3. QR 티켓 강제 재발급 - 비회원/회원 일부 QR 티켓 분실 시 이메일 재전송
+  /*
+   * 마이 페이지도 접근 안될 경우
+   * 1. "관리자 문의"
+   * 2. 관리자 승인 후 발급
+   * 3. 이메일로 발급 완료 메일 전송
+   * */
+  @PostMapping("/admin/reissue/send-email")
+  public ResponseEntity<QrTicketReissueResponseDto> reissueAdminQrTicket(@RequestBody QrTicketReissueRequestDto dto){
+    return ResponseEntity.ok(qrTicketService.reissueAdminQrTicket(dto));
   }
 
   // QR 티켓 만료

--- a/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
+++ b/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
@@ -32,10 +32,15 @@ public class QrTicketController {
     return ResponseEntity.ok(qrTicketService.issueGuest(token));
   }
 
+  // QR 티켓 재발급
+//  @PostMapping("/reissue/{token}")
+//  public ResponseEntity<QrTicketResponseDto> reissueQrTicket(@PathVariable String token) {
+//    return ResponseEntity.ok(qrTicketService.reissueQrTicket(token));
+//  }
+
   // QR 티켓 만료
 
-  // QR 티켓 재발급
+
 
   // QR 티켓 삭제?
-
 }

--- a/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
+++ b/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
@@ -3,6 +3,8 @@ package com.fairing.fairplay.qr.controller;
 
 import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
 import com.fairing.fairplay.qr.dto.QrTicketResponseDto;
+import com.fairing.fairplay.qr.dto.QrTicketUpdateRequestDto;
+import com.fairing.fairplay.qr.dto.QrTicketUpdateResponseDto;
 import com.fairing.fairplay.qr.service.QrTicketService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -33,14 +35,13 @@ public class QrTicketController {
   }
 
   // QR 티켓 재발급
-//  @PostMapping("/reissue/{token}")
-//  public ResponseEntity<QrTicketResponseDto> reissueQrTicket(@PathVariable String token) {
-//    return ResponseEntity.ok(qrTicketService.reissueQrTicket(token));
-//  }
+  @PostMapping("/reissue")
+  public ResponseEntity<QrTicketUpdateResponseDto> reissueQrTicket(
+      @RequestBody QrTicketUpdateRequestDto dto) {
+    return ResponseEntity.ok(qrTicketService.reissueQrTicket(dto));
+  }
 
   // QR 티켓 만료
-
-
 
   // QR 티켓 삭제?
 }

--- a/src/main/java/com/fairing/fairplay/qr/dto/QrTicketReissueRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/qr/dto/QrTicketReissueRequestDto.java
@@ -1,0 +1,17 @@
+package com.fairing.fairplay.qr.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class QrTicketReissueRequestDto {
+
+  private String ticketNo; // 재발급 요청한 티켓 번호
+}

--- a/src/main/java/com/fairing/fairplay/qr/dto/QrTicketReissueResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/qr/dto/QrTicketReissueResponseDto.java
@@ -1,0 +1,20 @@
+package com.fairing.fairplay.qr.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+// QR 티켓 강제 재발급 응답
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class QrTicketReissueResponseDto {
+
+  private String ticketNo; // 발급된 티켓 번호
+  private String email; // 이메일
+}

--- a/src/main/java/com/fairing/fairplay/qr/dto/QrTicketUpdateRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/qr/dto/QrTicketUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.fairing.fairplay.qr.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class QrTicketUpdateRequestDto {
+  private String qrUrlToken;
+}

--- a/src/main/java/com/fairing/fairplay/qr/dto/QrTicketUpdateResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/qr/dto/QrTicketUpdateResponseDto.java
@@ -1,0 +1,17 @@
+package com.fairing.fairplay.qr.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class QrTicketUpdateResponseDto {
+  private String qrCode;
+  private String manualCode;
+}

--- a/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
@@ -27,4 +27,6 @@ public interface QrTicketRepository extends JpaRepository<QrTicket, Long> {
   Optional<QrTicketResponseDto> findDtoById(@Param("qrTicketId") Long qrTicketId);
 
   Optional<QrTicket> findByAttendee(Attendee attendee);
+
+  QrTicket findByTicketNo(String ticketNo);
 }

--- a/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
@@ -28,5 +28,5 @@ public interface QrTicketRepository extends JpaRepository<QrTicket, Long> {
 
   Optional<QrTicket> findByAttendee(Attendee attendee);
 
-  QrTicket findByTicketNo(String ticketNo);
+  Optional<QrTicket> findByTicketNo(String ticketNo);
 }

--- a/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepositoryCustom.java
+++ b/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepositoryCustom.java
@@ -1,0 +1,47 @@
+package com.fairing.fairplay.qr.repository;
+
+import com.fairing.fairplay.attendee.entity.QAttendee;
+import com.fairing.fairplay.event.entity.QEvent;
+import com.fairing.fairplay.event.entity.QEventDetail;
+import com.fairing.fairplay.reservation.entity.QReservation;
+import com.fairing.fairplay.ticket.entity.QEventSchedule;
+import com.fairing.fairplay.ticket.entity.QTicket;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class QrTicketRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  public List<Tuple> findAllByEventDate(LocalDate targetDate){
+    QAttendee attendee = QAttendee.attendee;
+    QReservation reservation = QReservation.reservation;
+    QEvent event = QEvent.event;
+    QEventDetail eventDetail = QEventDetail.eventDetail;
+    QEventSchedule eventSchedule = QEventSchedule.eventSchedule;
+    QTicket ticket = QTicket.ticket;
+
+    // 참석자 정보, 이벤트 정보, 티켓 정보, 재입장 허용 여부, 스케줄 날짜+종료시간
+    return queryFactory
+        .select(attendee, event, ticket, reservation, eventDetail.reentryAllowed,
+            eventSchedule.date, eventSchedule.startTime, eventSchedule.endTime)
+        .from(attendee)
+        .join(attendee.reservation, reservation)
+        .join(reservation.schedule, eventSchedule)
+        .join(eventSchedule.event, event)
+        .join(reservation.ticket, ticket)
+        .join(event.eventDetail, eventDetail)
+        .where(
+            eventDetail.startDate.eq(targetDate)
+        )
+        .fetch();
+  }
+}

--- a/src/main/java/com/fairing/fairplay/qr/service/QrEmailService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrEmailService.java
@@ -1,0 +1,21 @@
+package com.fairing.fairplay.qr.service;
+
+import com.fairing.fairplay.core.email.entity.EmailServiceFactory;
+import com.fairing.fairplay.core.email.entity.EmailServiceFactory.EmailType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+// QR 이메일 서비스
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QrEmailService {
+
+  private final EmailServiceFactory emailServiceFactory;
+
+  public void sendQrEmail(String qrUrl, String email, String name) {
+    emailServiceFactory.getService(EmailType.QR_TICKET)
+        .send(email, name, qrUrl);
+  }
+}

--- a/src/main/java/com/fairing/fairplay/qr/service/QrLinkService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrLinkService.java
@@ -1,0 +1,24 @@
+package com.fairing.fairplay.qr.service;
+
+import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
+import com.fairing.fairplay.qr.util.QrLinkTokenGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+// QR 링크 서비스
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QrLinkService {
+  private final QrLinkTokenGenerator qrLinkTokenGenerator;
+
+  public String generateQrLink(QrTicketRequestDto dto){
+    String token = qrLinkTokenGenerator.generateToken(dto);
+    return "https://your-site.com/qr-tickets/" + token;
+  }
+
+  public QrTicketRequestDto decodeToDto(String token){
+    return qrLinkTokenGenerator.decodeToDto(token);
+  }
+}

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
@@ -4,6 +4,8 @@ import com.fairing.fairplay.attendee.entity.QAttendee;
 import com.fairing.fairplay.core.email.entity.EmailServiceFactory;
 import com.fairing.fairplay.core.email.entity.EmailServiceFactory.EmailType;
 import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
+import com.fairing.fairplay.qr.entity.QrTicket;
+import com.fairing.fairplay.qr.repository.QrTicketRepository;
 import com.fairing.fairplay.qr.util.QrLinkTokenGenerator;
 import com.fairing.fairplay.reservation.entity.QReservation;
 import com.fairing.fairplay.reservation.repository.ReservationRepositoryCustom;
@@ -13,6 +15,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 // QR티켓 스케줄러 관련 서비스
 @Slf4j
@@ -23,6 +26,8 @@ public class QrTicketBatchService {
   private final QrLinkTokenGenerator qrLinkTokenGenerator;
   private final EmailServiceFactory emailServiceFactory;
   private final ReservationRepositoryCustom reservationRepositoryCustom;
+  private final QrTicketInitProvider qrTicketInitProvider;
+  private final QrTicketRepository qrTicketRepository;
 
   // 행사 1일 남은 예약건 조회
   public List<Tuple> fetchQrTicketBatch() {
@@ -60,4 +65,13 @@ public class QrTicketBatchService {
       }
     }
   }
+
+  // QR 티켓 엔티티 생성 - 스케쥴러가 실행
+  @Transactional
+  public void createQrTicket() {
+    List<QrTicket> qrTickets = qrTicketInitProvider.scheduleCreateQrTicket();
+    qrTicketRepository.saveAll(qrTickets);
+  }
+
+  // 행사 종료된 모든 QR 티켓 qr코드, 수동 코드 삭제
 }

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
@@ -99,7 +99,11 @@ public class QrTicketBatchService {
           LocalDate date = tuple.get(5, LocalDate.class);
           LocalTime startTime = tuple.get(6, LocalTime.class);
           LocalTime endTime = tuple.get(7, LocalTime.class);
-          assert e != null;
+
+          if (e == null) {
+            throw new IllegalStateException("Event가 조회되지 않습니다.");
+          }
+
           String eventCode = e.getEventCode();
 
           log.info("[QrTicketInitProvider] List<Tuple> results - e: {}", e.getTitleKr());

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketInitProvider.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketInitProvider.java
@@ -41,6 +41,7 @@ public class QrTicketInitProvider {
   private final JPAQueryFactory queryFactory;
   private final CodeGenerator codeGenerator;
 
+  // 저장된 QR 티켓 조회
   public QrTicket load(QrTicketRequestDto dto, Integer attendeeTypeCodeId) {
     Attendee attendee;
 

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketInitProvider.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketInitProvider.java
@@ -43,6 +43,7 @@ public class QrTicketInitProvider {
         .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "QR 티켓을 조회할 수 없습니다."));
   }
 
+  // TODO: Attendee 조회 수정 예정
   private Attendee loadAttendeeWithTypeCheck(QrTicketRequestDto dto, Integer attendeeTypeCodeId) {
     if (attendeeTypeCodeId == 1) {
       return attendeeRepository.findByReservation_ReservationIdAndAttendeeTypeCode_Id(
@@ -61,6 +62,7 @@ public class QrTicketInitProvider {
   }
 
   // 재발급 할 때 attendee 조회
+  // TODO: Attendee 조회 수정 예정
   private Attendee loadAttendeeWithoutTypeCheck(QrTicketRequestDto dto) {
     Long reservationId = dto.getReservationId();
     if (dto.getAttendeeId() == null) {

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketInitProvider.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketInitProvider.java
@@ -1,28 +1,18 @@
 package com.fairing.fairplay.qr.service;
 
 import com.fairing.fairplay.attendee.entity.Attendee;
-import com.fairing.fairplay.attendee.entity.QAttendee;
+
 import com.fairing.fairplay.attendee.repository.AttendeeRepository;
 import com.fairing.fairplay.common.exception.CustomException;
-import com.fairing.fairplay.event.entity.Event;
-import com.fairing.fairplay.event.entity.QEvent;
-import com.fairing.fairplay.event.entity.QEventDetail;
+
 import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
 import com.fairing.fairplay.qr.entity.QrTicket;
 import com.fairing.fairplay.qr.repository.QrTicketRepository;
+import com.fairing.fairplay.qr.repository.QrTicketRepositoryCustom;
 import com.fairing.fairplay.qr.util.CodeGenerator;
-import com.fairing.fairplay.reservation.entity.QReservation;
-import com.fairing.fairplay.ticket.entity.EventTicket;
-import com.fairing.fairplay.ticket.entity.QEventSchedule;
-import com.fairing.fairplay.ticket.entity.QTicket;
-import com.fairing.fairplay.ticket.entity.Ticket;
-import com.querydsl.core.Tuple;
+
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
-import java.util.Objects;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -38,8 +28,7 @@ public class QrTicketInitProvider {
 
   private final AttendeeRepository attendeeRepository;
   private final QrTicketRepository qrTicketRepository;
-  private final JPAQueryFactory queryFactory;
-  private final CodeGenerator codeGenerator;
+
 
   // 저장된 QR 티켓 조회
   public QrTicket load(QrTicketRequestDto dto, Integer attendeeTypeCodeId) {
@@ -84,72 +73,5 @@ public class QrTicketInitProvider {
     } else {
       throw new CustomException(HttpStatus.BAD_REQUEST, "참석자 조회에 필요한 정보가 부족합니다.");
     }
-  }
-
-
-  /*
-   * 다음날 열리는 행사에 참석 예정인 모든 사람을 조회해
-   * 각 참석자에 대한 QR티켓을 발급 ( QR코드는 생성 안함 )
-   * */
-  public List<QrTicket> scheduleCreateQrTicket() {
-
-    // 현재 날짜 기준 다음날 시작하는 행사 데이터 추출
-    LocalDate targetDate = LocalDate.now().plusDays(1);
-
-    log.info("[QrTicketInitProvider] scheduleCreateQrTicket - targetDate: {}", targetDate);
-
-    QAttendee attendee = QAttendee.attendee;
-    QReservation reservation = QReservation.reservation;
-    QEvent event = QEvent.event;
-    QEventDetail eventDetail = QEventDetail.eventDetail;
-    QEventSchedule eventSchedule = QEventSchedule.eventSchedule;
-    QTicket ticket = QTicket.ticket;
-
-    // 참석자 정보, 이벤트 정보, 티켓 정보, 재입장 허용 여부, 스케줄 날짜+종료시간
-    List<Tuple> results = queryFactory
-        .select(attendee, event, ticket, reservation, eventDetail.reentryAllowed,
-            eventSchedule.date, eventSchedule.startTime, eventSchedule.endTime)
-        .from(attendee)
-        .join(attendee.reservation, reservation)
-        .join(reservation.schedule, eventSchedule)
-        .join(eventSchedule.event, event)
-        .join(reservation.ticket, ticket)
-        .join(event.eventDetail, eventDetail)
-        .where(
-            eventDetail.startDate.eq(targetDate)
-        )
-        .fetch();
-
-    log.info("[QrTicketInitProvider] scheduleCreateQrTicket results : {}",
-        results.getFirst().get(event));
-
-    return results.stream()
-        .map(tuple -> {
-          Attendee a = tuple.get(attendee);
-          Event e = tuple.get(event);
-          Ticket t = tuple.get(ticket);
-          Boolean reentryAllowed = tuple.get(eventDetail.reentryAllowed);
-          LocalDate date = tuple.get(eventSchedule.date);
-          LocalTime endTime = tuple.get(eventSchedule.endTime);
-          String eventCode = Objects.requireNonNull(tuple.get(event)).getEventCode();
-
-          log.info("[QrTicketInitProvider] List<Tuple> results - e: {}", e.getTitleKr());
-
-          LocalDateTime expiredAt = LocalDateTime.of(date, endTime); //만료시간 설정
-          String ticketNo = codeGenerator.generateTicketNo(eventCode); // 티켓번호 설정
-
-          return QrTicket.builder()
-              .attendee(a)
-              .eventTicket(new EventTicket(t, e))
-              .reentryAllowed(reentryAllowed)
-              .expiredAt(expiredAt)
-              .issuedAt(LocalDateTime.now())
-              .active(true)
-              .ticketNo(ticketNo)
-              .qrCode(null)
-              .manualCode(null)
-              .build();
-        })
-        .toList();
   }
 }

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketManager.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketManager.java
@@ -1,0 +1,193 @@
+package com.fairing.fairplay.qr.service;
+
+import com.fairing.fairplay.attendee.entity.Attendee;
+import com.fairing.fairplay.common.exception.CustomException;
+import com.fairing.fairplay.common.exception.LinkExpiredException;
+import com.fairing.fairplay.qr.dto.QrTicketReissueRequestDto;
+import com.fairing.fairplay.qr.dto.QrTicketReissueResponseDto;
+import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
+import com.fairing.fairplay.qr.dto.QrTicketResponseDto;
+import com.fairing.fairplay.qr.dto.QrTicketResponseDto.ViewingScheduleInfo;
+import com.fairing.fairplay.qr.dto.QrTicketUpdateRequestDto;
+import com.fairing.fairplay.qr.dto.QrTicketUpdateResponseDto;
+import com.fairing.fairplay.qr.entity.QrTicket;
+import com.fairing.fairplay.qr.repository.QrTicketRepository;
+import com.fairing.fairplay.qr.util.CodeGenerator;
+import com.fairing.fairplay.reservation.entity.Reservation;
+import com.fairing.fairplay.reservation.repository.ReservationRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// QR Ticket 발급 및 저장
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class QrTicketManager {
+
+  private final QrTicketRepository qrTicketRepository;
+  private final ReservationRepository reservationRepository;
+  private final CodeGenerator codeGenerator;
+  private final QrTicketInitProvider qrTicketInitProvider;
+  private final QrLinkService qrLinkService;
+  private final QrEmailService qrEmailService;
+
+  // 회원 QR 티켓 조회 -> 마이페이지에서 조회
+  @Transactional
+  public QrTicketResponseDto issueMemberTicket(QrTicketRequestDto dto) {
+    Reservation reservation = checkReservationBeforeNow(dto.getReservationId());
+
+    QrTicket savedTicket = generateAndSaveQrTicket(dto, 1);
+    return buildQrTicketResponse(savedTicket.getId(), reservation.getCreatedAt());
+  }
+
+  // 비회원 QR 티켓 조회 -> QR 티켓 링크 통한 조회
+  @Transactional
+  public QrTicketResponseDto issueGuestTicket(String token) {
+    // 토큰 파싱해 예약 정보 조회
+    QrTicketRequestDto dto = qrLinkService.decodeToDto(token);
+
+    Reservation reservation = checkReservationBeforeNow(dto.getReservationId());
+
+    // QR 티켓 조회해 qr code, manualcode 생성해서 반환
+    QrTicket savedTicket = generateAndSaveQrTicket(dto, 2);
+    // 프론트 응답
+    return buildQrTicketResponse(savedTicket.getId(), reservation.getCreatedAt());
+  }
+
+  // QR 티켓 재발급 - 새로고침 버튼
+  @Transactional
+  public QrTicketUpdateResponseDto reissueQrTicket(QrTicketUpdateRequestDto dto) {
+    // QR URL 디코딩
+    QrTicketRequestDto qrTicketRequestDto = qrLinkService.decodeToDto(dto.getQrUrlToken());
+
+    // 예약 여부 조회
+    Reservation reservation = checkReservationBeforeNow(qrTicketRequestDto.getReservationId());
+
+    // QR 티켓 재발급
+    QrTicket savedTicket = generateAndSaveQrTicket(qrTicketRequestDto, null);
+    return QrTicketUpdateResponseDto.builder().qrCode(savedTicket.getQrCode())
+        .manualCode(savedTicket.getManualCode()).build();
+  }
+
+//  // 마이 페이지 강제 QR 티켓 재발급 - 행사 관리자
+//  @Transactional
+//  public QrTicketReissueResponseDto reissueByAdmin(QrTicketReissueRequestDto dto) {
+//    QrTicket
+//    // attendeeId 받음
+//
+//    // 참석자 ID 조회
+//    Attendee attendee = attendeeRepository.findById(attendeeId);
+//
+//    // qr url 재발급
+//    String qrUrl = qrLinkService.generateQrLink(dto);
+//
+//    // 메일 전송
+//    qrEmailService.sendQrEmail(qrUrl, name, email);
+//    // 메일 전송 성공 응답 - 메일 내용: 성공만 했다. url은 마이페이지에서 확인해라
+//  }
+
+
+  // 관리자 강제 QR 티켓 링크 재발급
+  @Transactional
+  public QrTicketReissueResponseDto reissueByAdmin(QrTicketReissueRequestDto dto) {
+    QrTicket qrTicket = qrTicketRepository.findByTicketNo(dto.getTicketNo());
+
+    // 재발급된 QR 티켓 - qrcode, manualcode null 처리
+    QrTicket resetQrTicket = resetQrTicket(qrTicket);
+    Attendee attendee = resetQrTicket.getAttendee();
+
+    QrTicketRequestDto qrTicketRequestDto = QrTicketRequestDto.builder()
+        .reservationId(resetQrTicket.getAttendee().getReservation().getReservationId())
+        .eventId(resetQrTicket.getEventTicket().getEvent().getEventId())
+        .ticketId(resetQrTicket.getEventTicket().getTicket().getTicketId())
+        .attendeeId(resetQrTicket.getAttendee().getId())
+        .build();
+
+    // 메일 전송
+    String qrUrl = qrLinkService.generateQrLink(qrTicketRequestDto);
+    qrEmailService.sendQrEmail(qrUrl, attendee.getEmail(), attendee.getName());
+
+    // 메일 전송 성공 응답 - 메일 내용: 성공했다. 메일로 qr url 보냇다.
+    return buildQrTicketReissueResponse(resetQrTicket.getTicketNo(), attendee.getEmail());
+  }
+
+  // 행사일이 오늘보다 전날 또는 행사일이 오늘인데 종료 시간이 현재 시간보다 더 늦은 경우 예외 처리
+  private Reservation checkReservationBeforeNow(Long reservationId) {
+    Reservation reservation = reservationRepository.findById(reservationId)
+        .orElseThrow(() -> new CustomException(
+            HttpStatus.NOT_FOUND, "올바른 예약 티켓이 아닙니다."));
+
+    LocalDate nowDate = LocalDate.now(ZoneId.of("Asia/Seoul"));
+    LocalTime nowTime = LocalTime.now(ZoneId.of("Asia/Seoul"));
+
+    if (reservation.getSchedule().getDate().isBefore(nowDate) || (
+        reservation.getSchedule().getDate().isEqual(nowDate) && reservation.getSchedule()
+            .getEndTime().isBefore(nowTime))) {
+      throw new LinkExpiredException("종료된 행사입니다.", null);
+    }
+
+    return reservation;
+  }
+
+  // 저장된 qr 티켓 조회 후 qrcode, manualcode 발급받아 저장
+  private QrTicket generateAndSaveQrTicket(QrTicketRequestDto dto, Integer type) {
+    QrTicket qrTicket = findQrTicket(dto, type);
+    qrTicket.setQrCode(codeGenerator.generateRandomToken());
+    qrTicket.setManualCode(codeGenerator.generateManualCode());
+    return qrTicketRepository.save(qrTicket);
+  }
+
+  private QrTicket resetQrTicket(QrTicket qrTicket) {
+    qrTicket.setQrCode(null);
+    qrTicket.setManualCode(null);
+    return qrTicketRepository.save(qrTicket);
+  }
+
+  private QrTicket findQrTicket(QrTicketRequestDto dto, Integer type) {
+    return qrTicketInitProvider.load(dto, type);
+  }
+
+  // 재발급 응답 생성
+  private QrTicketReissueResponseDto buildQrTicketReissueResponse(String ticketNo, String email) {
+    return QrTicketReissueResponseDto.builder()
+        .ticketNo(ticketNo)
+        .email(email)
+        .build();
+  }
+
+  // 발급 응답 생성
+  private QrTicketResponseDto buildQrTicketResponse(Long ticketId,
+      LocalDateTime reservationCreatedAt) {
+    QrTicketResponseDto dto = qrTicketRepository.findDtoById(ticketId)
+        .orElseThrow(() -> new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "티켓 조회 실패"));
+
+    if (reservationCreatedAt != null) {
+      String formattedDate = reservationCreatedAt.format(
+          DateTimeFormatter.ofPattern("yyyy. MM. dd"));
+      dto.setReservationDate(formattedDate);
+    }
+
+    // 가상의 상영 정보 설정 예시
+    ViewingScheduleInfo viewingScheduleInfo = getMockSchedule();
+    dto.setViewingScheduleInfo(viewingScheduleInfo);
+    return dto;
+  }
+
+  // 삭제 예정
+  private ViewingScheduleInfo getMockSchedule() {
+    return ViewingScheduleInfo.builder()
+        .date("2025-08-01")
+        .dayOfWeek("금")
+        .startTime("14:00")
+        .build();
+  }
+
+}

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketManager.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketManager.java
@@ -98,7 +98,9 @@ public class QrTicketManager {
   // 관리자 강제 QR 티켓 링크 재발급
   @Transactional
   public QrTicketReissueResponseDto reissueByAdmin(QrTicketReissueRequestDto dto) {
-    QrTicket qrTicket = qrTicketRepository.findByTicketNo(dto.getTicketNo());
+    QrTicket qrTicket = qrTicketRepository.findByTicketNo(dto.getTicketNo()).orElseThrow(
+        () -> new CustomException(HttpStatus.NOT_FOUND,"티켓 번호에 해당하는 QR 티켓을 찾을 수 없습니다: "+dto.getTicketNo())
+    );
 
     // 재발급된 QR 티켓 - qrcode, manualcode null 처리
     QrTicket resetQrTicket = resetQrTicket(qrTicket);
@@ -145,12 +147,14 @@ public class QrTicketManager {
     return qrTicketRepository.save(qrTicket);
   }
 
+  // QR 티켓 초기화
   private QrTicket resetQrTicket(QrTicket qrTicket) {
     qrTicket.setQrCode(null);
     qrTicket.setManualCode(null);
     return qrTicketRepository.save(qrTicket);
   }
 
+  // QR 티켓 조회
   private QrTicket findQrTicket(QrTicketRequestDto dto, Integer type) {
     return qrTicketInitProvider.load(dto, type);
   }
@@ -181,7 +185,7 @@ public class QrTicketManager {
     return dto;
   }
 
-  // 삭제 예정
+  // TODO: 실제 스케줄 정보 조회 로직으로 교체 예정
   private ViewingScheduleInfo getMockSchedule() {
     return ViewingScheduleInfo.builder()
         .date("2025-08-01")

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketService.java
@@ -1,26 +1,13 @@
 package com.fairing.fairplay.qr.service;
 
-import com.fairing.fairplay.common.exception.CustomException;
-import com.fairing.fairplay.common.exception.LinkExpiredException;
+import com.fairing.fairplay.qr.dto.QrTicketReissueRequestDto;
+import com.fairing.fairplay.qr.dto.QrTicketReissueResponseDto;
 import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
 import com.fairing.fairplay.qr.dto.QrTicketResponseDto;
-import com.fairing.fairplay.qr.dto.QrTicketResponseDto.ViewingScheduleInfo;
 import com.fairing.fairplay.qr.dto.QrTicketUpdateRequestDto;
 import com.fairing.fairplay.qr.dto.QrTicketUpdateResponseDto;
-import com.fairing.fairplay.qr.entity.QrTicket;
-import com.fairing.fairplay.qr.repository.QrTicketRepository;
-import com.fairing.fairplay.qr.util.CodeGenerator;
-import com.fairing.fairplay.qr.util.QrLinkTokenGenerator;
-import com.fairing.fairplay.reservation.entity.Reservation;
-import com.fairing.fairplay.reservation.repository.ReservationRepository;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,99 +17,45 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class QrTicketService {
 
-  private final QrTicketRepository qrTicketRepository;
-  private final ReservationRepository reservationRepository;
-  private final QrLinkTokenGenerator qrLinkTokenGenerator;
-  private final CodeGenerator codeGenerator;
-  private final QrTicketInitProvider qrTicketInitProvider;
+  private final QrTicketManager qrTicketManager;
 
   // 회원 QR 티켓 조회 -> 마이페이지에서 조회
   @Transactional
   public QrTicketResponseDto issueMember(QrTicketRequestDto dto) {
-    Reservation reservation = checkReservationBeforeNow(dto.getReservationId());
-
-    QrTicket savedTicket = generateAndSaveQrTicket(dto, 1);
-    return buildQrTicketResponse(savedTicket.getId(), reservation.getCreatedAt());
+    return qrTicketManager.issueMemberTicket(dto);
   }
 
   // 비회원 QR 티켓 조회 -> QR 티켓 링크 통한 조회
   @Transactional
   public QrTicketResponseDto issueGuest(String token) {
-    // 토큰 파싱해 예약 정보 조회
-    QrTicketRequestDto dto = qrLinkTokenGenerator.decodeToDto(token);
-
-    Reservation reservation = checkReservationBeforeNow(dto.getReservationId());
-
-    // QR 티켓 조회해 qr code, manualcode 생성해서 반환
-    QrTicket savedTicket = generateAndSaveQrTicket(dto, 2);
-    // 프론트 응답
-    return buildQrTicketResponse(savedTicket.getId(), reservation.getCreatedAt());
+    return qrTicketManager.issueGuestTicket(token);
   }
 
-  // QR 티켓 재발급
+  // QR 티켓 재발급 - 새로고침 버튼
   @Transactional
   public QrTicketUpdateResponseDto reissueQrTicket(QrTicketUpdateRequestDto dto) {
-    // QR URL 디코딩
-    QrTicketRequestDto qrTicketRequestDto = qrLinkTokenGenerator.decodeToDto(dto.getQrUrlToken());
-
-    // 예약 여부 조회
-    Reservation reservation = checkReservationBeforeNow(qrTicketRequestDto.getReservationId());
-
-    // QR 티켓 재발급
-    QrTicket savedTicket = generateAndSaveQrTicket(qrTicketRequestDto, null);
-    return QrTicketUpdateResponseDto.builder().qrCode(savedTicket.getQrCode())
-        .manualCode(savedTicket.getManualCode()).build();
+    return qrTicketManager.reissueQrTicket(dto);
   }
 
-  // 행사일이 오늘보다 전날 또는 행사일이 오늘인데 종료 시간이 현재 시간보다 더 늦은 경우 예외 처리
-  private Reservation checkReservationBeforeNow(Long reservationId) {
-    Reservation reservation = reservationRepository.findById(reservationId)
-        .orElseThrow(() -> new CustomException(
-            HttpStatus.NOT_FOUND, "올바른 예약 티켓이 아닙니다."));
-
-    LocalDate nowDate = LocalDate.now(ZoneId.of("Asia/Seoul"));
-    LocalTime nowTime = LocalTime.now(ZoneId.of("Asia/Seoul"));
-
-    if (reservation.getSchedule().getDate().isBefore(nowDate) || (
-        reservation.getSchedule().getDate().isEqual(nowDate) && reservation.getSchedule()
-            .getEndTime().isBefore(nowTime))) {
-      throw new LinkExpiredException("종료된 행사입니다.", null);
-    }
-
-    return reservation;
+  // 관리자 강제 QR 티켓 링크 재발급
+  @Transactional
+  public QrTicketReissueResponseDto reissueAdminQrTicket(QrTicketReissueRequestDto dto) {
+    return qrTicketManager.reissueByAdmin(dto);
   }
 
-  // 저장된 qr 티켓 조회 후 qrcode, manualcode 발급받아 저장
-  private QrTicket generateAndSaveQrTicket(QrTicketRequestDto dto, Integer type) {
-    QrTicket qrTicket = qrTicketInitProvider.load(dto, type);
-    qrTicket.setQrCode(codeGenerator.generateRandomToken());
-    qrTicket.setManualCode(codeGenerator.generateManualCode());
-    return qrTicketRepository.save(qrTicket);
-  }
-
-  // 프론트 응답 설정
-  private QrTicketResponseDto buildQrTicketResponse(Long ticketId,
-      LocalDateTime reservationCreatedAt) {
-    QrTicketResponseDto dto = qrTicketRepository.findDtoById(ticketId)
-        .orElseThrow(() -> new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "티켓 조회 실패"));
-
-    if (reservationCreatedAt != null) {
-      String formattedDate = reservationCreatedAt.format(
-          DateTimeFormatter.ofPattern("yyyy. MM. dd"));
-      dto.setReservationDate(formattedDate);
-    }
-
-    // 가상의 상영 정보 설정 예시
-    ViewingScheduleInfo viewingScheduleInfo = getMockSchedule();
-    dto.setViewingScheduleInfo(viewingScheduleInfo);
-    return dto;
-  }
-
-  private ViewingScheduleInfo getMockSchedule() {
-    return ViewingScheduleInfo.builder()
-        .date("2025-08-01")
-        .dayOfWeek("금")
-        .startTime("14:00")
-        .build();
-  }
+  // 마이 페이지 강제 QR 티켓 재발급 - 행사 관리자
+//  @Transactional
+//  public QrTicketReissueResponseDto reissueAdminQrTicket(QrTicketUpdateRequestDto dto) {
+//    // attendeeId 받음
+//
+//    // 참석자 ID 조회
+//    Attendee attendee = attendeeRepository.findById(attendeeId);
+//
+//    // qr url 재발급
+//    String qrUrl = qrLinkService.generateQrLink(dto);
+//
+//    // 메일 전송
+//    qrEmailService.sendQrEmail(qrUrl, name, email);
+//    // 메일 전송 성공 응답 - 메일 내용: 성공만 했다. url은 마이페이지에서 확인해라
+//  }
 }

--- a/src/main/java/com/fairing/fairplay/qr/util/QrLinkTokenGenerator.java
+++ b/src/main/java/com/fairing/fairplay/qr/util/QrLinkTokenGenerator.java
@@ -1,20 +1,20 @@
 package com.fairing.fairplay.qr.util;
 
+import com.fairing.fairplay.common.exception.LinkExpiredException;
 import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.hashids.Hashids;
 import org.springframework.stereotype.Component;
 
-// QR 티켓링크용 토큰 관련 유틸 클래스
+// QR 티켓 조회용 토큰 관련 유틸 클래스
 @Component
 @RequiredArgsConstructor
 public class QrLinkTokenGenerator {
 
   private final Hashids hashids;
 
-  // 암호화한 문자열 토큰 생성
+  // QR 티켓 조회 화면 token
   public String generateToken(QrTicketRequestDto dto) {
-
     // hashids는 long 배열만 받음
     // 숫자 배열을 인코딩해 짧고 URL 안전한 문자열로 만듦
     // ex. nk2s0
@@ -30,18 +30,18 @@ public class QrLinkTokenGenerator {
 
   // 암호화된 문자열을 DTO 객체로 만듦
   public QrTicketRequestDto decodeToDto(String token) {
-    if(token == null || token.trim().isEmpty()) {
+    if (token == null || token.trim().isEmpty()) {
       throw new IllegalArgumentException("QR 링크 토큰이 비어 있습니다.");
     }
 
-    try{
+    try {
       long[] numbers = decodeToken(token);
       // 디코딩 결과 배열 길이 체크
       if (numbers.length < 4) {
         throw new IllegalArgumentException("유효하지 않은 QR 토큰 형식입니다.");
       }
 
-      if(numbers[0] == 0 && numbers[1] == 0 && numbers[2] == 0 && numbers[3] == 0){
+      if (numbers[0] == 0 && numbers[1] == 0 && numbers[2] == 0 && numbers[3] == 0) {
         throw new IllegalArgumentException("유효하지 않은 QR 토큰 데이터입니다.");
       }
 
@@ -51,7 +51,7 @@ public class QrLinkTokenGenerator {
           .eventId(numbers[2] == 0 ? null : numbers[2])
           .ticketId(numbers[3] == 0 ? null : numbers[3])
           .build();
-    }catch(Exception e){
+    } catch (Exception e) {
       throw new IllegalArgumentException("토큰 디코딩 중 오류가 발생했습니다: " + e.getMessage(), e);
     }
   }

--- a/src/main/java/com/fairing/fairplay/qr/util/QrLinkTokenGenerator.java
+++ b/src/main/java/com/fairing/fairplay/qr/util/QrLinkTokenGenerator.java
@@ -1,6 +1,5 @@
 package com.fairing.fairplay.qr.util;
 
-import com.fairing.fairplay.common.exception.LinkExpiredException;
 import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.hashids.Hashids;

--- a/src/main/java/com/fairing/fairplay/scheduler/ShareTicketQrScheduler.java
+++ b/src/main/java/com/fairing/fairplay/scheduler/ShareTicketQrScheduler.java
@@ -1,5 +1,6 @@
 package com.fairing.fairplay.scheduler;
 
+import com.fairing.fairplay.qr.service.QrTicketBatchService;
 import com.fairing.fairplay.qr.service.QrTicketService;
 import com.fairing.fairplay.shareticket.entity.ShareTicket;
 import com.fairing.fairplay.shareticket.service.ShareTicketService;
@@ -17,7 +18,7 @@ import org.springframework.stereotype.Component;
 public class ShareTicketQrScheduler {
 
   private final ShareTicketService shareTicketService;
-  private final QrTicketService qrTicketService;
+  private final QrTicketBatchService qrTicketBatchService;
 
   // 공유 폼 링크 만료
   /*
@@ -51,7 +52,7 @@ public class ShareTicketQrScheduler {
       }
     }
     // 2. 만료 완료 후 QR 티켓 세팅
-    qrTicketService.createQrTicket();
+    qrTicketBatchService.createQrTicket();
   }
 */
 }


### PR DESCRIPTION
## 변경 사항
- 사용자가 새로고침 버튼 클릭해 QR 코드 재발급
- 관리자 강제 QR 티켓 재발급
- QR 티켓 관련 서비스 코드 분리 

## 추가 사항
- 재발급 관련 사용자 검증 로직 추가 예정

## 관련 이슈
#36 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * QR 티켓 재발급(이미지 및 수기코드 갱신) 및 관리자의 강제 재발급/이메일 재발송 기능이 추가되었습니다.
  * QR 티켓 발급, 재발급, 조회, 이메일 발송 등 QR 티켓 관련 서비스가 세분화 및 개선되었습니다.
  * 예약 및 이벤트 일정에 따른 QR 티켓 일괄 생성 및 이메일 발송 배치 기능이 도입되었습니다.

* **리팩터링**
  * QR 티켓 발급 및 재발급 로직이 서비스, 매니저, 배치 서비스 등으로 분리되어 구조가 개선되었습니다.
  * QR 티켓 초기화 및 조회 로직이 명확하게 재구성되고, 책임이 분리되었습니다.

* **문서화**
  * 주요 클래스 및 메서드에 주석이 보강되어 각 재발급 시나리오 및 처리 조건이 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->