### PR TITLE
feat: 배너 로그 외래키 변경

### DIFF
--- a/src/main/java/com/fairing/fairplay/banner/entity/BannerLog.java
+++ b/src/main/java/com/fairing/fairplay/banner/entity/BannerLog.java
@@ -5,7 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import com.fairing.fairplay.admin.entity.AdminAccount;
+import com.fairing.fairplay.user.entity.Users;
 
 import java.time.LocalDateTime;
 
@@ -26,7 +26,7 @@ public class BannerLog {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "changed_by", nullable = false)
-    private AdminAccount changedBy;
+    private Users changedBy;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "banner_action_code_id", nullable = false)
@@ -41,7 +41,7 @@ public class BannerLog {
     }
 
     @Builder
-    public BannerLog(Banner banner, AdminAccount changedBy, BannerActionCode actionCode) {
+    public BannerLog(Banner banner, Users changedBy, BannerActionCode actionCode) {
         this.banner = banner;
         this.changedBy = changedBy;
         this.actionCode = actionCode;

--- a/src/main/java/com/fairing/fairplay/banner/service/BannerService.java
+++ b/src/main/java/com/fairing/fairplay/banner/service/BannerService.java
@@ -3,13 +3,14 @@ package com.fairing.fairplay.banner.service;
 import com.fairing.fairplay.banner.dto.*;
 import com.fairing.fairplay.banner.entity.*;
 import com.fairing.fairplay.banner.repository.*;
-import com.fairing.fairplay.admin.entity.AdminAccount;
 import com.fairing.fairplay.core.service.AwsS3Service;
 import com.fairing.fairplay.file.dto.S3UploadRequestDto;
 import com.fairing.fairplay.file.dto.S3UploadResponseDto;
 import com.fairing.fairplay.file.service.FileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import com.fairing.fairplay.user.entity.Users;
+
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -140,12 +141,11 @@ public class BannerService {
         BannerActionCode actionCode = bannerActionCodeRepository.findByCode(actionCodeStr)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 배너 액션 코드: " + actionCodeStr));
 
-        // adminId만으로 proxy admin 객체 생성
-        AdminAccount proxyAdmin = new AdminAccount(adminId);
+        Users proxyUser = new Users(adminId);
 
         BannerLog log = BannerLog.builder()
                 .banner(banner)
-                .changedBy(proxyAdmin)
+                .changedBy(proxyUser)
                 .actionCode(actionCode)
                 .build();
 

--- a/src/main/java/com/fairing/fairplay/user/entity/Users.java
+++ b/src/main/java/com/fairing/fairplay/user/entity/Users.java
@@ -65,4 +65,8 @@ public class Users {
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
+
+    public Users(Long userId) {
+        this.userId = userId;
+    }
 }


### PR DESCRIPTION
-admin_account -> users
-users.java 추가
 public Users(Long userId) {
        this.userId = userId;
    }

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * `Users` 엔티티에 `userId`를 받는 생성자가 추가되었습니다.

* **리팩터링**
  * 배너 로그의 변경자 정보가 `AdminAccount`에서 `Users`로 변경되었습니다.  
  * 관련 서비스 로직이 `Users` 엔티티를 사용하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->