### PR TITLE
feat: 부스 체험 및 체험 예약 관리 기능 구현

### DIFF
--- a/src/main/http/booth_experience.http
+++ b/src/main/http/booth_experience.http
@@ -1,4 +1,18 @@
-### ===============================
+### 부스 관리자 로그인 (체험 등록/관리용)
+POST {{baseUrl}}/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "b1@f.com",
+  "password": "1234"
+}
+
+> {%
+    if (response.status === 200) {
+        client.global.set("access_token", response.body.accessToken);
+        console.log("Booth Access token saved: " + response.body.accessToken);
+    }
+%}
 
 ### 변수 설정
 @baseUrl = http://localhost:8080
@@ -6,8 +20,8 @@
 @experienceId = 3
 @reservationId = 2
 @userId = 1
-@access_token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzOCIsImVtYWlsIjoiZTFAZi5jb20iLCJyb2xlIjoi7ZaJ7IKsIOuLtOuLueyekCIsInJvbGVJZCI6MiwiaWF0IjoxNzU0NzA5MjAzLCJleHAiOjE3NTQ3MDk4MDN9.JjfyTPD-1VVbfYDWRZwiu7c-NFfSEls6XhicMaHjt6M
-@booth_access_token = {{booth_access_token}}
+@access_token = {{ access_token }}
+@booth_access_token = {{ booth_access_token }}
 
 
 ### 부스 체험 API 테스트
@@ -326,3 +340,71 @@ Authorization: Bearer {{access_token}}
   "statusCode": "CANCELLED",
   "notes": "완료된 예약 취소 시도"
 }
+
+### ===============================
+### 동시성 테스트 케이스
+### ===============================
+
+### 동시 예약 테스트 1 - 동일한 체험에 여러 사용자가 동시 예약
+POST {{baseUrl}}/api/booth-experiences/{{experienceId}}/reservations?userId=1
+Content-Type: application/json
+
+{
+  "notes": "동시성 테스트 - 사용자 1"
+}
+
+### 동시 예약 테스트 2 - 동일한 체험에 여러 사용자가 동시 예약
+POST {{baseUrl}}/api/booth-experiences/{{experienceId}}/reservations?userId=2
+Content-Type: application/json
+
+{
+  "notes": "동시성 테스트 - 사용자 2"
+}
+
+### 동시 예약 테스트 3 - 동일한 체험에 여러 사용자가 동시 예약
+POST {{baseUrl}}/api/booth-experiences/{{experienceId}}/reservations?userId=3
+Content-Type: application/json
+
+{
+  "notes": "동시성 테스트 - 사용자 3"
+}
+
+### 동시 예약 테스트 4 - 동일한 체험에 여러 사용자가 동시 예약
+POST {{baseUrl}}/api/booth-experiences/{{experienceId}}/reservations?userId=4
+Content-Type: application/json
+
+{
+  "notes": "동시성 테스트 - 사용자 4"
+}
+
+### 동시 예약 테스트 5 - 동일한 체험에 여러 사용자가 동시 예약
+POST {{baseUrl}}/api/booth-experiences/{{experienceId}}/reservations?userId=5
+Content-Type: application/json
+
+{
+  "notes": "동시성 테스트 - 사용자 5"
+}
+
+### 대기 순번 확인 - 위의 동시 예약들이 순차적으로 배정되었는지 확인
+GET {{baseUrl}}/api/booth-experiences/{{experienceId}}/queue-status
+Content-Type: application/json
+
+### ===============================
+### 동시성 테스트 시나리오 설명
+### ===============================
+### 
+### 테스트 목적: Pessimistic Lock이 올바르게 동작하는지 확인
+### 
+### 1. 위의 5개 예약 요청을 동시에 실행 (IntelliJ HTTP Client에서 Ctrl+Enter로 빠르게 연속 실행)
+### 2. 대기열 상태 조회로 queuePosition이 1, 2, 3, 4, 5로 중복 없이 순차 배정되었는지 확인
+### 3. 만약 동시성 처리가 제대로 되지 않았다면 같은 queuePosition을 가진 예약들이 발생할 수 있음
+### 
+### 기대 결과:
+### - 모든 예약이 성공적으로 생성됨
+### - queuePosition이 중복 없이 1부터 순차적으로 배정됨
+### - 데이터베이스 무결성이 유지됨
+### 
+### 추가 테스트:
+### - 동일한 사용자가 중복 예약을 시도하는 경우
+### - 최대 대기 인원을 초과하여 예약하는 경우
+### - Lock timeout이 발생하는 경우 (5초 초과 대기)

--- a/src/main/http/booth_experience.http
+++ b/src/main/http/booth_experience.http
@@ -158,10 +158,11 @@ Authorization: Bearer {{access_token}}
 }
 
 ### ===============================
-### 10. 예약 취소 (참여자)
+### 10. 예약 취소 (참여자) - 본인 인증 포함
 ### ===============================
-DELETE {{baseUrl}}/api/booth-experiences/reservations/{{reservationId}}?userId={{userId}}
+DELETE {{baseUrl}}/api/booth-experiences/reservations/{{reservationId}}
 Content-Type: application/json
+Authorization: Bearer {{access_token}}
 
 ### ===============================
 ### 11. 대기열 현황 조회

--- a/src/main/http/booth_experience.http
+++ b/src/main/http/booth_experience.http
@@ -1,0 +1,327 @@
+### ===============================
+
+### 변수 설정
+@baseUrl = http://localhost:8080
+@boothId = 1
+@experienceId = 3
+@reservationId = 2
+@userId = 1
+@access_token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzOCIsImVtYWlsIjoiZTFAZi5jb20iLCJyb2xlIjoi7ZaJ7IKsIOuLtOuLueyekCIsInJvbGVJZCI6MiwiaWF0IjoxNzU0NzA5MjAzLCJleHAiOjE3NTQ3MDk4MDN9.JjfyTPD-1VVbfYDWRZwiu7c-NFfSEls6XhicMaHjt6M
+@booth_access_token = {{booth_access_token}}
+
+
+### 부스 체험 API 테스트
+
+### ===============================
+### 0. 부스 신청/등록 (전제 조건)
+### ===============================
+
+### 0-1. 부스 신청 (일반 사용자)
+POST {{baseUrl}}/api/booth/applications
+Content-Type: application/json
+
+{
+  "eventId": 8,
+  "boothTypeId": 1,
+  "boothTitle": "테크 체험 부스",
+  "boothDescription": "최신 IT 기술을 체험할 수 있는 부스입니다. VR, AR, AI 등 다양한 기술 체험 가능",
+  "managerName": "김부스",
+  "email": "b1@f.com",
+  "contactNumber": "010-1234-5678",
+  "officialUrl": "https://techbooth.example.com",
+  "startDate": "2025-02-15",
+  "endDate": "2025-02-16",
+  "isDeleted": false
+}
+
+### 0-2. 부스 신청 목록 조회 (행사 관리자)
+GET {{baseUrl}}/api/booth/applications?eventId=8
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+### 0-3. 부스 신청 승인 (행사 관리자) - 실제 Booth 엔티티 생성됨
+@applicationId = 9
+PUT {{baseUrl}}/api/booth/applications/{{applicationId}}/status
+Authorization: Bearer {{access_token}}
+Content-Type: application/json
+
+{
+  "statusCode": "APPROVED",
+  "adminComment": "부스 신청이 승인되었습니다. 체험 프로그램을 등록해주세요."
+}
+
+### 0-4. 결제 상태 업데이트 (관리자)
+PUT {{baseUrl}}/api/booth/applications/{{applicationId}}/payment-status
+Authorization: Bearer {{access_token}}
+Content-Type: application/json
+
+{
+  "paymentStatusCode": "PAID",
+  "adminComment": "부스 운영비 결제가 완료되었습니다."
+}
+
+
+
+
+
+### ===============================
+### 1. 부스 체험 등록 (부스 담당자)
+### ===============================
+POST {{baseUrl}}/api/booth-experiences/booths/{{boothId}}
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "title": "VR 체험존",
+  "description": "최신 VR 기술을 이용한 가상현실 체험",
+  "experienceDate": "2025-08-20",
+  "startTime": "09:00:00",
+  "endTime": "18:00:00",
+  "durationMinutes": 10,
+  "maxCapacity": 4,
+  "allowWaiting": true,
+  "maxWaitingCount": 20,
+  "allowDuplicateReservation": true,
+  "isReservationEnabled": true
+}
+
+### ===============================
+### 2. 특정 부스의 체험 목록 조회 (부스 담당자용)
+### ===============================
+GET {{baseUrl}}/api/booth-experiences/booths/{{boothId}}
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+### ===============================
+### 3. 예약 가능한 모든 부스 체험 목록 조회 (참여자용)
+### ===============================
+GET {{baseUrl}}/api/booth-experiences/available
+Content-Type: application/json
+
+### ===============================
+### 4. 부스 체험 예약 신청 (참여자)
+### ===============================
+POST {{baseUrl}}/api/booth-experiences/{{experienceId}}/reservations?userId={{userId}}
+Content-Type: application/json
+
+{
+  "notes": "처음 VR 체험이라 도움이 필요할 수 있습니다"
+}
+
+### ===============================
+### 5. 특정 체험의 예약자 목록 조회 (부스 담당자용)
+### ===============================
+GET {{baseUrl}}/api/booth-experiences/{{experienceId}}/reservations
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+### ===============================
+### 6. 내 예약 목록 조회 (참여자용)
+### ===============================
+GET {{baseUrl}}/api/booth-experiences/my-reservations?userId={{userId}}
+Content-Type: application/json
+
+### ===============================
+### 7. 예약 상태 변경: 대기중 -> 입장가능 (부스 담당자)
+### ===============================
+PUT {{baseUrl}}/api/booth-experiences/reservations/{{reservationId}}/status
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "statusCode": "READY",
+  "notes": "1번 대기자님 입장 가능합니다"
+}
+
+### ===============================
+### 8. 예약 상태 변경: 입장가능 -> 체험중 (부스 담당자)
+### ===============================
+PUT {{baseUrl}}/api/booth-experiences/reservations/{{reservationId}}/status
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "statusCode": "IN_PROGRESS",
+  "notes": "체험 시작"
+}
+
+### ===============================
+### 9. 예약 상태 변경: 체험중 -> 완료 (부스 담당자)
+### ===============================
+PUT {{baseUrl}}/api/booth-experiences/reservations/{{reservationId}}/status
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "statusCode": "COMPLETED",
+  "notes": "체험 완료, 만족도 높음"
+}
+
+### ===============================
+### 10. 예약 취소 (참여자)
+### ===============================
+DELETE {{baseUrl}}/api/booth-experiences/reservations/{{reservationId}}?userId={{userId}}
+Content-Type: application/json
+
+### ===============================
+### 11. 대기열 현황 조회
+### ===============================
+GET {{baseUrl}}/api/booth-experiences/{{experienceId}}/queue-status
+Content-Type: application/json
+
+
+
+
+
+
+
+### ===============================
+### 테스트 시나리오 예제
+### ===============================
+
+### 시나리오 1: 새로운 체험 등록 후 예약까지의 전체 플로우
+### Step 1: 체험 등록
+POST {{baseUrl}}/api/booth-experiences/booths/1
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "title": "AI 그림 그리기 체험",
+  "description": "AI와 함께하는 디지털 아트 창작 체험",
+  "experienceDate": "2025-02-16",
+  "startTime": "10:00:00",
+  "endTime": "17:00:00",
+  "durationMinutes": 15,
+  "maxCapacity": 2,
+  "allowWaiting": true,
+  "maxWaitingCount": 10,
+  "allowDuplicateReservation": false,
+  "isReservationEnabled": true
+}
+
+### Step 2: 예약 가능한 체험 목록에서 확인
+GET {{baseUrl}}/api/booth-experiences/available
+Content-Type: application/json
+
+### Step 3: 예약 신청 (여러 사용자)
+POST {{baseUrl}}/api/booth-experiences/2/reservations?userId=38
+Content-Type: application/json
+
+{
+  "notes": "첫 번째 예약자입니다"
+}
+
+###
+POST {{baseUrl}}/api/booth-experiences/2/reservations?userId=2
+Content-Type: application/json
+
+{
+  "notes": "두 번째 예약자입니다"
+}
+
+###
+POST {{baseUrl}}/api/booth-experiences/2/reservations?userId=3
+Content-Type: application/json
+
+{
+  "notes": "세 번째 예약자입니다 (대기열)"
+}
+
+### Step 4: 대기열 상황 확인
+GET {{baseUrl}}/api/booth-experiences/2/queue-status
+Content-Type: application/json
+
+### ===============================
+### 시나리오 2: 상태 변경 플로우 테스트
+### ===============================
+
+### 첫 번째 대기자를 READY로 변경
+PUT {{baseUrl}}/api/booth-experiences/reservations/1/status
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "statusCode": "READY",
+  "notes": "첫 번째 대기자님 준비되셨으면 오세요"
+}
+
+### 두 번째 대기자를 READY로 변경 
+PUT {{baseUrl}}/api/booth-experiences/reservations/2/status
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "statusCode": "READY",
+  "notes": "두 번째 대기자님도 준비 완료"
+}
+
+### 첫 번째 사용자 체험 시작
+PUT {{baseUrl}}/api/booth-experiences/reservations/1/status
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "statusCode": "IN_PROGRESS",
+  "notes": "체험 시작"
+}
+
+### 첫 번째 사용자 체험 완료 (자동으로 다음 대기자 호출됨)
+PUT {{baseUrl}}/api/booth-experiences/reservations/1/status
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "statusCode": "COMPLETED",
+  "notes": "체험 완료 - 매우 만족"
+}
+
+### 완료 후 대기열 상황 재확인
+GET {{baseUrl}}/api/booth-experiences/3/queue-status
+Content-Type: application/json
+
+### ===============================
+### 에러 케이스 테스트
+### ===============================
+
+### 존재하지 않는 부스에 체험 등록 시도
+POST {{baseUrl}}/api/booth-experiences/booths/999
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "title": "존재하지 않는 부스 테스트",
+  "description": "에러 발생 테스트",
+  "experienceDate": "2025-02-15",
+  "startTime": "09:00:00",
+  "endTime": "18:00:00",
+  "durationMinutes": 10,
+  "maxCapacity": 4
+}
+
+### 존재하지 않는 사용자 예약 시도
+POST {{baseUrl}}/api/booth-experiences/1/reservations?userId=999
+Content-Type: application/json
+
+{
+  "notes": "존재하지 않는 사용자"
+}
+
+### 잘못된 상태 변경 시도 (WAITING -> COMPLETED 직접 변경)
+PUT {{baseUrl}}/api/booth-experiences/reservations/1/status
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "statusCode": "COMPLETED",
+  "notes": "잘못된 상태 변경 테스트"
+}
+
+### 이미 완료된 예약 상태 변경 시도
+PUT {{baseUrl}}/api/booth-experiences/reservations/1/status
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "statusCode": "CANCELLED",
+  "notes": "완료된 예약 취소 시도"
+}

--- a/src/main/http/user.http
+++ b/src/main/http/user.http
@@ -1,0 +1,119 @@
+### 변수 설정
+@baseUrl = http://localhost:8080
+
+### ===============================
+### 회원가입 (테스트용 사용자 생성)
+### ===============================
+
+### 일반 사용자 회원가입
+POST {{baseUrl}}/api/users/signup
+Content-Type: application/json
+
+{
+  "email": "u1@f.com",
+  "password": "1234",
+  "name": "사용자1",
+  "nickname": "user1",
+  "phone": "010-1111-1111",
+  "roleCodeId": 4
+}
+
+### 부스 관리자 회원가입
+POST {{baseUrl}}/api/users/signup
+Content-Type: application/json
+
+{
+  "email": "b1@f.com",
+  "password": "1234",
+  "name": "부스1",
+  "nickname": "boothM1",
+  "phone": "010-2222-2222",
+  "roleCodeId": 3
+}
+
+### 행사 관리자 회원가입
+POST {{baseUrl}}/api/users/signup
+Content-Type: application/json
+
+{
+  "email": "e1@f.com",
+  "password": "1234",
+  "name": "행사1",
+  "nickname": "eventM1",
+  "phone": "010-3333-3333",
+  "roleCodeId": 2
+}
+
+### 전체 관리자 회원가입
+POST {{baseUrl}}/api/users/signup
+Content-Type: application/json
+
+{
+  "email": "a1@f.com",
+  "password": "1234",
+  "name": "전체1",
+  "nickname": "전체1",
+  "phone": "010-4444-4444",
+  "roleCodeId": 1
+}
+
+### 이메일 중복 확인
+GET {{baseUrl}}/api/users/check-email?email=test@example.com
+Content-Type: application/json
+
+### 닉네임 중복 확인
+GET {{baseUrl}}/api/users/check-nickname?nickname=testuser
+Content-Type: application/json
+
+### ===============================
+### 로그인 및 토큰 획득
+### ===============================
+
+### 행사 관리자 로그인 (부스 신청 승인용)
+POST {{baseUrl}}/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "e1@f.com",
+  "password": "1234"
+}
+
+> {%
+    if (response.status === 200) {
+        client.global.set("access_token", response.body.accessToken);
+        console.log("Access token saved: " + response.body.accessToken);
+    }
+%}
+
+### 부스 관리자 로그인 (체험 등록/관리용)
+POST {{baseUrl}}/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "b1@f.com",
+  "password": "1234"
+}
+
+> {%
+    if (response.status === 200) {
+        client.global.set("booth_access_token", response.body.accessToken);
+        console.log("Booth Access token saved: " + response.body.accessToken);
+    }
+%}
+
+
+### 전체 관리자 로그인
+POST {{baseUrl}}/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "a1@f.com",
+  "password": "1234"
+}
+
+> {%
+    if (response.status === 200) {
+        client.global.set("booth_access_token", response.body.accessToken);
+        console.log("Booth Access token saved: " + response.body.accessToken);
+    }
+%}

--- a/src/main/java/com/fairing/fairplay/booth/controller/BoothExperienceController.java
+++ b/src/main/java/com/fairing/fairplay/booth/controller/BoothExperienceController.java
@@ -2,12 +2,14 @@ package com.fairing.fairplay.booth.controller;
 
 import com.fairing.fairplay.booth.dto.*;
 import com.fairing.fairplay.booth.service.BoothExperienceService;
+import com.fairing.fairplay.core.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -121,17 +123,13 @@ public class BoothExperienceController {
     @DeleteMapping("/reservations/{reservationId}")
     public ResponseEntity<Void> cancelReservation(
             @Parameter(description = "예약 ID") @PathVariable Long reservationId,
-            @Parameter(description = "사용자 ID") @RequestParam Long userId) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         
+        Long userId = userDetails.getUserId();
         log.info("예약 취소 - 예약 ID: {}, 사용자 ID: {}", reservationId, userId);
         
-        // 취소 상태로 변경
-        BoothExperienceStatusUpdateDto cancelDto = BoothExperienceStatusUpdateDto.builder()
-                .statusCode("CANCELLED")
-                .notes("사용자 취소")
-                .build();
-        
-        boothExperienceService.updateReservationStatus(reservationId, cancelDto);
+        // 본인 예약 확인 및 취소 처리
+        boothExperienceService.cancelUserReservation(reservationId, userId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/fairing/fairplay/booth/controller/BoothExperienceController.java
+++ b/src/main/java/com/fairing/fairplay/booth/controller/BoothExperienceController.java
@@ -1,0 +1,157 @@
+package com.fairing.fairplay.booth.controller;
+
+import com.fairing.fairplay.booth.dto.*;
+import com.fairing.fairplay.booth.service.BoothExperienceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "부스 체험 관리", description = "부스 체험 등록, 예약, 상태 관리 API")
+@Slf4j
+@RestController
+@RequestMapping("/api/booth-experiences")
+@RequiredArgsConstructor
+public class BoothExperienceController {
+
+    private final BoothExperienceService boothExperienceService;
+
+    // 1. 부스 체험 등록 (부스 담당자)
+    @Operation(summary = "부스 체험 등록", description = "부스 담당자가 새로운 체험을 등록합니다.")
+    @PostMapping("/booths/{boothId}")
+    public ResponseEntity<BoothExperienceResponseDto> createBoothExperience(
+            @Parameter(description = "부스 ID") @PathVariable Long boothId,
+            @RequestBody BoothExperienceRequestDto requestDto) {
+        
+        log.info("부스 체험 등록 요청 - 부스 ID: {}", boothId);
+        BoothExperienceResponseDto response = boothExperienceService.createBoothExperience(boothId, requestDto);
+        return ResponseEntity.ok(response);
+    }
+
+    // 2. 부스 체험 목록 조회 (부스 담당자용)
+    @Operation(summary = "부스 체험 목록 조회", description = "특정 부스의 모든 체험 목록을 조회합니다.")
+    @GetMapping("/booths/{boothId}")
+    public ResponseEntity<List<BoothExperienceResponseDto>> getBoothExperiences(
+            @Parameter(description = "부스 ID") @PathVariable Long boothId) {
+        
+        log.info("부스 체험 목록 조회 - 부스 ID: {}", boothId);
+        List<BoothExperienceResponseDto> experiences = boothExperienceService.getBoothExperiences(boothId);
+        return ResponseEntity.ok(experiences);
+    }
+
+    // 3. 체험 가능한 부스 체험 목록 조회 (참여자용)
+    @Operation(summary = "체험 가능한 부스 목록", description = "현재 예약 가능한 모든 부스 체험을 조회합니다.")
+    @GetMapping("/available")
+    public ResponseEntity<List<BoothExperienceResponseDto>> getAvailableExperiences() {
+        
+        log.info("체험 가능한 부스 목록 조회");
+        List<BoothExperienceResponseDto> experiences = boothExperienceService.getAvailableExperiences();
+        return ResponseEntity.ok(experiences);
+    }
+
+    // 4. 부스 체험 상세 조회
+    /*@Operation(summary = "부스 체험 상세 조회", description = "특정 체험의 상세 정보를 조회합니다.")
+    @GetMapping("/{experienceId}")
+    public ResponseEntity<BoothExperienceResponseDto> getBoothExperience(
+            @Parameter(description = "체험 ID") @PathVariable Long experienceId) {
+
+        log.info("부스 체험 상세 조회 - 체험 ID: {}", experienceId);
+        // 단일 조회 메서드 필요시 Service에 추가 구현 필요
+        return ResponseEntity.notImplemented().build();
+    }*/
+
+    // 5. 부스 체험 예약 신청 (참여자)
+    @Operation(summary = "부스 체험 예약", description = "사용자가 부스 체험을 예약합니다.")
+    @PostMapping("/{experienceId}/reservations")
+    public ResponseEntity<BoothExperienceReservationResponseDto> createReservation(
+            @Parameter(description = "체험 ID") @PathVariable Long experienceId,
+            @Parameter(description = "사용자 ID") @RequestParam Long userId,
+            @RequestBody BoothExperienceReservationRequestDto requestDto) {
+        
+        log.info("부스 체험 예약 요청 - 체험 ID: {}, 사용자 ID: {}", experienceId, userId);
+        BoothExperienceReservationResponseDto response = boothExperienceService.createReservation(
+                experienceId, userId, requestDto);
+        return ResponseEntity.ok(response);
+    }
+
+    // 6. 부스 체험 예약자 목록 조회 (부스 담당자용)
+    @Operation(summary = "예약자 목록 조회", description = "특정 체험의 모든 예약자 목록을 조회합니다.")
+    @GetMapping("/{experienceId}/reservations")
+    public ResponseEntity<List<BoothExperienceReservationResponseDto>> getExperienceReservations(
+            @Parameter(description = "체험 ID") @PathVariable Long experienceId) {
+        
+        log.info("예약자 목록 조회 - 체험 ID: {}", experienceId);
+        List<BoothExperienceReservationResponseDto> reservations = 
+                boothExperienceService.getExperienceReservations(experienceId);
+        return ResponseEntity.ok(reservations);
+    }
+
+    // 7. 내 예약 목록 조회 (참여자용)
+    @Operation(summary = "내 예약 목록", description = "사용자의 모든 예약 내역을 조회합니다.")
+    @GetMapping("/my-reservations")
+    public ResponseEntity<List<BoothExperienceReservationResponseDto>> getMyReservations(
+            @Parameter(description = "사용자 ID") @RequestParam Long userId) {
+        
+        log.info("내 예약 목록 조회 - 사용자 ID: {}", userId);
+        List<BoothExperienceReservationResponseDto> reservations = 
+                boothExperienceService.getMyReservations(userId);
+        return ResponseEntity.ok(reservations);
+    }
+
+    // 8. 예약 상태 변경 (부스 담당자)
+    @Operation(summary = "예약 상태 변경", description = "부스 담당자가 예약의 상태를 변경합니다.")
+    @PutMapping("/reservations/{reservationId}/status")
+    public ResponseEntity<BoothExperienceReservationResponseDto> updateReservationStatus(
+            @Parameter(description = "예약 ID") @PathVariable Long reservationId,
+            @RequestBody BoothExperienceStatusUpdateDto updateDto) {
+        
+        log.info("예약 상태 변경 - 예약 ID: {}, 상태: {}", reservationId, updateDto.getStatusCode());
+        BoothExperienceReservationResponseDto response = boothExperienceService.updateReservationStatus(
+                reservationId, updateDto);
+        return ResponseEntity.ok(response);
+    }
+
+    // 9. 예약 취소 (참여자)
+    @Operation(summary = "예약 취소", description = "사용자가 자신의 예약을 취소합니다.")
+    @DeleteMapping("/reservations/{reservationId}")
+    public ResponseEntity<Void> cancelReservation(
+            @Parameter(description = "예약 ID") @PathVariable Long reservationId,
+            @Parameter(description = "사용자 ID") @RequestParam Long userId) {
+        
+        log.info("예약 취소 - 예약 ID: {}, 사용자 ID: {}", reservationId, userId);
+        
+        // 취소 상태로 변경
+        BoothExperienceStatusUpdateDto cancelDto = BoothExperienceStatusUpdateDto.builder()
+                .statusCode("CANCELLED")
+                .notes("사용자 취소")
+                .build();
+        
+        boothExperienceService.updateReservationStatus(reservationId, cancelDto);
+        return ResponseEntity.ok().build();
+    }
+
+    // 10. 대기열 상태 조회
+    @Operation(summary = "대기열 상태 조회", description = "특정 체험의 현재 대기열 상태를 조회합니다.")
+    @GetMapping("/{experienceId}/queue-status")
+    public ResponseEntity<List<BoothExperienceReservationResponseDto>> getQueueStatus(
+            @Parameter(description = "체험 ID") @PathVariable Long experienceId) {
+        
+        log.info("대기열 상태 조회 - 체험 ID: {}", experienceId);
+        List<BoothExperienceReservationResponseDto> reservations = 
+                boothExperienceService.getExperienceReservations(experienceId);
+        
+        // 대기중이거나 진행중인 예약만 필터링
+        List<BoothExperienceReservationResponseDto> activeReservations = reservations.stream()
+                .filter(r -> "WAITING".equals(r.getStatusCode()) || 
+                           "READY".equals(r.getStatusCode()) || 
+                           "IN_PROGRESS".equals(r.getStatusCode()))
+                .toList();
+        
+        return ResponseEntity.ok(activeReservations);
+    }
+}

--- a/src/main/java/com/fairing/fairplay/booth/dto/BoothExperienceRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/booth/dto/BoothExperienceRequestDto.java
@@ -1,0 +1,36 @@
+package com.fairing.fairplay.booth.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoothExperienceRequestDto {
+
+    private String title; // 체험 제목
+
+    private String description; // 체험 설명
+
+    private LocalDate experienceDate; // 체험 날짜
+
+    private LocalTime startTime; // 운영 시작 시간
+
+    private LocalTime endTime; // 운영 종료 시간
+
+    private Integer durationMinutes; // 체험 소요 시간 (분)
+
+    private Integer maxCapacity; // 최대 동시 체험 인원
+
+    private Boolean allowWaiting; // 대기열 허용 여부
+
+    private Integer maxWaitingCount; // 최대 대기 인원
+
+    private Boolean allowDuplicateReservation; // 중복 예약 허용 여부
+
+    private Boolean isReservationEnabled; // 예약 가능 여부
+}

--- a/src/main/java/com/fairing/fairplay/booth/dto/BoothExperienceReservationRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/booth/dto/BoothExperienceReservationRequestDto.java
@@ -1,0 +1,13 @@
+package com.fairing.fairplay.booth.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoothExperienceReservationRequestDto {
+
+    private String notes; // 특이사항 또는 메모 (선택사항)
+}

--- a/src/main/java/com/fairing/fairplay/booth/dto/BoothExperienceReservationResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/booth/dto/BoothExperienceReservationResponseDto.java
@@ -1,0 +1,77 @@
+package com.fairing.fairplay.booth.dto;
+
+import com.fairing.fairplay.booth.entity.BoothExperienceReservation;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoothExperienceReservationResponseDto {
+
+    private Long reservationId; // 예약 ID
+
+    private Long experienceId; // 체험 ID
+
+    private String experienceTitle; // 체험 제목
+
+    private Long boothId; // 부스 ID
+
+    private String boothName; // 부스명
+
+    private Long userId; // 예약자 ID
+
+    private String userName; // 예약자 이름
+
+    private String statusCode; // 상태 코드
+
+    private String statusName; // 상태명
+
+    private Integer queuePosition; // 대기 순번
+
+    private LocalDateTime reservedAt; // 예약일시
+
+    private LocalDateTime readyAt; // 입장 가능 시간
+
+    private LocalDateTime startedAt; // 체험 시작 시간
+
+    private LocalDateTime completedAt; // 체험 완료 시간
+
+    private LocalDateTime cancelledAt; // 취소 시간
+
+    private Long waitingMinutes; // 대기 시간 (분)
+
+    private Long experienceDurationMinutes; // 체험 소요 시간 (분)
+
+    private String notes; // 특이사항 또는 메모
+
+    private Boolean isActive; // 활성 상태 여부
+
+    // 엔티티에서 DTO로 변환
+    public static BoothExperienceReservationResponseDto fromEntity(BoothExperienceReservation entity) {
+        return BoothExperienceReservationResponseDto.builder()
+                .reservationId(entity.getReservationId())
+                .experienceId(entity.getBoothExperience().getExperienceId())
+                .experienceTitle(entity.getBoothExperience().getTitle())
+                .boothId(entity.getBoothExperience().getBooth().getId())
+                .boothName(entity.getBoothExperience().getBooth().getBoothTitle())
+                .userId(entity.getUser().getUserId())
+                .userName(entity.getUser().getName())
+                .statusCode(entity.getExperienceStatusCode().getCode())
+                .statusName(entity.getExperienceStatusCode().getName())
+                .queuePosition(entity.getQueuePosition())
+                .reservedAt(entity.getReservedAt())
+                .readyAt(entity.getReadyAt())
+                .startedAt(entity.getStartedAt())
+                .completedAt(entity.getCompletedAt())
+                .cancelledAt(entity.getCancelledAt())
+                .waitingMinutes(entity.getWaitingMinutes())
+                .experienceDurationMinutes(entity.getExperienceDurationMinutes())
+                .notes(entity.getNotes())
+                .isActive(entity.isActive())
+                .build();
+    }
+}

--- a/src/main/java/com/fairing/fairplay/booth/dto/BoothExperienceResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/booth/dto/BoothExperienceResponseDto.java
@@ -1,0 +1,82 @@
+package com.fairing.fairplay.booth.dto;
+
+import com.fairing.fairplay.booth.entity.BoothExperience;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoothExperienceResponseDto {
+
+    private Long experienceId; // 체험 ID
+
+    private Long boothId; // 부스 ID
+
+    private String boothName; // 부스명
+
+    private String title; // 체험 제목
+
+    private String description; // 체험 설명
+
+    private LocalDate experienceDate; // 체험 날짜
+
+    private LocalTime startTime; // 운영 시작 시간
+
+    private LocalTime endTime; // 운영 종료 시간
+
+    private Integer durationMinutes; // 체험 소요 시간
+
+    private Integer maxCapacity; // 최대 동시 체험 인원
+
+    private Integer currentParticipants; // 현재 체험중 인원
+
+    private Integer waitingCount; // 현재 대기 인원
+
+    private Double congestionRate; // 혼잡도 (%)
+
+    private Boolean allowWaiting; // 대기열 허용 여부
+
+    private Integer maxWaitingCount; // 최대 대기 인원
+
+    private Boolean allowDuplicateReservation; // 중복 예약 허용 여부
+
+    private Boolean isReservationEnabled; // 예약 가능 여부
+
+    private Boolean isReservationAvailable; // 현재 예약 가능 상태
+
+    private LocalDateTime createdAt; // 등록일시
+
+    private LocalDateTime updatedAt; // 수정일시
+
+    // 엔티티에서 DTO로 변환
+    public static BoothExperienceResponseDto fromEntity(BoothExperience entity) {
+        return BoothExperienceResponseDto.builder()
+                .experienceId(entity.getExperienceId())
+                .boothId(entity.getBooth().getId())
+                .boothName(entity.getBooth().getBoothTitle())
+                .title(entity.getTitle())
+                .description(entity.getDescription())
+                .experienceDate(entity.getExperienceDate())
+                .startTime(entity.getStartTime())
+                .endTime(entity.getEndTime())
+                .durationMinutes(entity.getDurationMinutes())
+                .maxCapacity(entity.getMaxCapacity())
+                .currentParticipants(entity.getCurrentParticipants())
+                .waitingCount(entity.getWaitingCount())
+                .congestionRate(entity.getCongestionRate())
+                .allowWaiting(entity.getAllowWaiting())
+                .maxWaitingCount(entity.getMaxWaitingCount())
+                .allowDuplicateReservation(entity.getAllowDuplicateReservation())
+                .isReservationEnabled(entity.getIsReservationEnabled())
+                .isReservationAvailable(entity.isReservationAvailable())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/fairing/fairplay/booth/dto/BoothExperienceStatusUpdateDto.java
+++ b/src/main/java/com/fairing/fairplay/booth/dto/BoothExperienceStatusUpdateDto.java
@@ -1,0 +1,15 @@
+package com.fairing.fairplay.booth.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoothExperienceStatusUpdateDto {
+
+    private String statusCode; // 변경할 상태 코드 (WAITING, READY, IN_PROGRESS, COMPLETED, CANCELLED)
+
+    private String notes; // 상태 변경 사유 또는 메모 (선택사항)
+}

--- a/src/main/java/com/fairing/fairplay/booth/entity/BoothExperience.java
+++ b/src/main/java/com/fairing/fairplay/booth/entity/BoothExperience.java
@@ -1,0 +1,119 @@
+package com.fairing.fairplay.booth.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Entity
+@Table(name = "booth_experience")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoothExperience {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "experience_id")
+    private Long experienceId; // 체험 ID (PK)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booth_id", nullable = false)
+    private Booth booth; // 부스 정보 (FK)
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title; // 체험 제목
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description; // 체험 설명
+
+    @Column(name = "experience_date", nullable = false)
+    private LocalDate experienceDate; // 체험 날짜
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime; // 운영 시작 시간 (예: 09:00)
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime; // 운영 종료 시간 (예: 18:00)
+
+    @Column(name = "duration_minutes", nullable = false)
+    private Integer durationMinutes; // 체험 소요 시간 (분 단위, 예: 20분)
+
+    @Column(name = "max_capacity", nullable = false)
+    private Integer maxCapacity; // 최대 동시 체험 인원
+
+    @Builder.Default
+    @Column(name = "allow_waiting")
+    private Boolean allowWaiting = true; // 대기열 허용 여부
+
+    @Column(name = "max_waiting_count")
+    private Integer maxWaitingCount; // 최대 대기 인원 (null이면 무제한)
+
+    @Builder.Default
+    @Column(name = "allow_duplicate_reservation")
+    private Boolean allowDuplicateReservation = false; // 사용자 중복 예약 허용 여부
+
+    @Builder.Default
+    @Column(name = "is_reservation_enabled")
+    private Boolean isReservationEnabled = true; // 예약 가능 여부
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt; // 등록일시
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt; // 수정일시
+
+    @OneToMany(mappedBy = "boothExperience", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BoothExperienceReservation> reservations; // 예약 목록
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    // 현재 체험중 인원 수 (계산 필드)
+    public Integer getCurrentParticipants() {
+        if (reservations == null) return 0;
+        return (int) reservations.stream()
+                .filter(r -> "IN_PROGRESS".equals(r.getExperienceStatusCode().getCode()))
+                .count();
+    }
+
+    // 현재 대기 인원 수 (계산 필드)
+    public Integer getWaitingCount() {
+        if (reservations == null) return 0;
+        return (int) reservations.stream()
+                .filter(r -> "WAITING".equals(r.getExperienceStatusCode().getCode()) || 
+                           "READY".equals(r.getExperienceStatusCode().getCode()))
+                .count();
+    }
+
+    // 혼잡도 계산 (0-100)
+    public Double getCongestionRate() {
+        if (maxCapacity == 0) return 0.0;
+        return (getCurrentParticipants().doubleValue() / maxCapacity) * 100.0;
+    }
+
+    // 예약 가능 여부 확인
+    public Boolean isReservationAvailable() {
+        if (!isReservationEnabled) return false;
+        if (!allowWaiting) {
+            return getCurrentParticipants() < maxCapacity;
+        }
+        if (maxWaitingCount != null) {
+            return getWaitingCount() < maxWaitingCount;
+        }
+        return true; // 대기열 허용하고 최대 대기 수 제한 없으면 항상 가능
+    }
+}

--- a/src/main/java/com/fairing/fairplay/booth/entity/BoothExperienceReservation.java
+++ b/src/main/java/com/fairing/fairplay/booth/entity/BoothExperienceReservation.java
@@ -1,0 +1,88 @@
+package com.fairing.fairplay.booth.entity;
+
+import com.fairing.fairplay.user.entity.Users;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "booth_experience_reservation")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoothExperienceReservation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reservation_id")
+    private Long reservationId; // 예약 ID (PK)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "experience_id", nullable = false)
+    private BoothExperience boothExperience; // 체험 정보 (FK)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user; // 예약자 정보 (FK)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "status_code_id", nullable = false)
+    private BoothExperienceStatusCode experienceStatusCode; // 체험 진행 상태 (FK)
+
+    @Column(name = "queue_position")
+    private Integer queuePosition; // 대기 순번 (1부터 시작)
+
+    @Column(name = "reserved_at", nullable = false)
+    private LocalDateTime reservedAt; // 예약일시 (대기 순서 기준)
+
+    @Column(name = "ready_at")
+    private LocalDateTime readyAt; // 입장 가능 알림 시간
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt; // 체험 시작 시간
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt; // 체험 완료 시간
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt; // 취소 시간
+
+    @Column(name = "notes", length = 500)
+    private String notes; // 특이사항 또는 메모
+
+    @PrePersist
+    protected void onCreate() {
+        if (reservedAt == null) {
+            reservedAt = LocalDateTime.now();
+        }
+    }
+
+    // 대기 시간 계산 (분 단위)
+    public Long getWaitingMinutes() {
+        if (reservedAt == null) return 0L;
+        
+        LocalDateTime endTime = switch (experienceStatusCode.getCode()) {
+            case "READY" -> readyAt != null ? readyAt : LocalDateTime.now();
+            case "IN_PROGRESS" -> startedAt != null ? startedAt : LocalDateTime.now();
+            case "COMPLETED" -> completedAt != null ? completedAt : LocalDateTime.now();
+            case "CANCELLED" -> cancelledAt != null ? cancelledAt : LocalDateTime.now();
+            default -> LocalDateTime.now();
+        };
+        
+        return java.time.Duration.between(reservedAt, endTime).toMinutes();
+    }
+
+    // 체험 소요 시간 계산 (분 단위)
+    public Long getExperienceDurationMinutes() {
+        if (startedAt == null || completedAt == null) return 0L;
+        return java.time.Duration.between(startedAt, completedAt).toMinutes();
+    }
+
+    // 현재 상태가 활성 상태인지 확인 (취소되지 않은 상태)
+    public Boolean isActive() {
+        return !"CANCELLED".equals(experienceStatusCode.getCode());
+    }
+}

--- a/src/main/java/com/fairing/fairplay/booth/entity/BoothExperienceStatusCode.java
+++ b/src/main/java/com/fairing/fairplay/booth/entity/BoothExperienceStatusCode.java
@@ -1,0 +1,25 @@
+package com.fairing.fairplay.booth.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "booth_experience_status_code")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoothExperienceStatusCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "status_code_id")
+    private Integer statusCodeId; // 상태 코드 ID (PK)
+
+    @Column(name = "code", nullable = false, unique = true, length = 20)
+    private String code; // 상태 코드 (WAITING, READY, IN_PROGRESS, COMPLETED, CANCELLED)
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name; // 상태명 (대기중, 입장가능, 체험중, 완료, 취소)
+}

--- a/src/main/java/com/fairing/fairplay/booth/repository/BoothExperienceRepository.java
+++ b/src/main/java/com/fairing/fairplay/booth/repository/BoothExperienceRepository.java
@@ -1,0 +1,39 @@
+package com.fairing.fairplay.booth.repository;
+
+import com.fairing.fairplay.booth.entity.Booth;
+import com.fairing.fairplay.booth.entity.BoothExperience;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface BoothExperienceRepository extends JpaRepository<BoothExperience, Long> {
+
+    // 부스별 체험 목록 조회
+    List<BoothExperience> findByBooth(Booth booth);
+
+    // 부스 ID로 체험 목록 조회
+    List<BoothExperience> findByBooth_Id(Long boothId);
+
+    // 특정 날짜의 체험 목록 조회
+    List<BoothExperience> findByExperienceDate(LocalDate date);
+
+    // 부스별 특정 날짜 체험 목록 조회
+    List<BoothExperience> findByBoothAndExperienceDate(Booth booth, LocalDate date);
+
+    // 예약 가능한 체험 목록 조회 (예약 활성화 상태)
+    @Query("SELECT be FROM BoothExperience be WHERE be.isReservationEnabled = true AND be.experienceDate >= :today")
+    List<BoothExperience> findAvailableExperiences(@Param("today") LocalDate today);
+
+    // 특정 이벤트의 모든 부스 체험 조회
+    @Query("SELECT be FROM BoothExperience be WHERE be.booth.event.eventId = :eventId")
+    List<BoothExperience> findByEventId(@Param("eventId") Long eventId);
+
+    // 특정 이벤트의 특정 날짜 체험 조회
+    @Query("SELECT be FROM BoothExperience be WHERE be.booth.event.eventId = :eventId AND be.experienceDate = :date")
+    List<BoothExperience> findByEventIdAndDate(@Param("eventId") Long eventId, @Param("date") LocalDate date);
+}

--- a/src/main/java/com/fairing/fairplay/booth/repository/BoothExperienceRepository.java
+++ b/src/main/java/com/fairing/fairplay/booth/repository/BoothExperienceRepository.java
@@ -2,13 +2,18 @@ package com.fairing.fairplay.booth.repository;
 
 import com.fairing.fairplay.booth.entity.Booth;
 import com.fairing.fairplay.booth.entity.BoothExperience;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BoothExperienceRepository extends JpaRepository<BoothExperience, Long> {
@@ -36,4 +41,10 @@ public interface BoothExperienceRepository extends JpaRepository<BoothExperience
     // 특정 이벤트의 특정 날짜 체험 조회
     @Query("SELECT be FROM BoothExperience be WHERE be.booth.event.eventId = :eventId AND be.experienceDate = :date")
     List<BoothExperience> findByEventIdAndDate(@Param("eventId") Long eventId, @Param("date") LocalDate date);
+
+    // Pessimistic Lock을 사용한 체험 조회 (동시성 제어)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "5000")})  // 5초 타임아웃
+    @Query("SELECT e FROM BoothExperience e WHERE e.experienceId = :experienceId")
+    Optional<BoothExperience> findByIdWithPessimisticLock(@Param("experienceId") Long experienceId);
 }

--- a/src/main/java/com/fairing/fairplay/booth/repository/BoothExperienceReservationRepository.java
+++ b/src/main/java/com/fairing/fairplay/booth/repository/BoothExperienceReservationRepository.java
@@ -46,10 +46,10 @@ public interface BoothExperienceReservationRepository extends JpaRepository<Boot
            "AND ber.experienceStatusCode.code = 'IN_PROGRESS'")
     List<BoothExperienceReservation> findInProgressReservations(@Param("experience") BoothExperience experience);
 
-    // 다음 대기 순번 조회
+    // 다음 대기 순번 조회 (WAITING 상태만 대상으로 최적화)
     @Query("SELECT COALESCE(MAX(ber.queuePosition), 0) + 1 FROM BoothExperienceReservation ber " +
-           "WHERE ber.boothExperience = :experience AND ber.experienceStatusCode.code IN ('WAITING', 'READY')")
-    Integer findNextQueuePosition(@Param("experience") BoothExperience experience);
+           "WHERE ber.boothExperience.experienceId = :experienceId AND ber.experienceStatusCode.code = 'WAITING'")
+    Integer findNextQueuePosition(@Param("experienceId") Long experienceId);
 
     // 사용자별 특정 이벤트 예약 목록
     @Query("SELECT ber FROM BoothExperienceReservation ber WHERE ber.user = :user " +

--- a/src/main/java/com/fairing/fairplay/booth/repository/BoothExperienceReservationRepository.java
+++ b/src/main/java/com/fairing/fairplay/booth/repository/BoothExperienceReservationRepository.java
@@ -1,0 +1,58 @@
+package com.fairing.fairplay.booth.repository;
+
+import com.fairing.fairplay.booth.entity.BoothExperience;
+import com.fairing.fairplay.booth.entity.BoothExperienceReservation;
+import com.fairing.fairplay.booth.entity.BoothExperienceStatusCode;
+import com.fairing.fairplay.user.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BoothExperienceReservationRepository extends JpaRepository<BoothExperienceReservation, Long> {
+
+    // 체험별 예약 목록 조회 (예약 시간 순)
+    List<BoothExperienceReservation> findByBoothExperienceOrderByReservedAt(BoothExperience boothExperience);
+
+    // 사용자별 예약 목록 조회 (최신순)
+    List<BoothExperienceReservation> findByUserOrderByReservedAtDesc(Users user);
+
+    // 특정 상태의 예약 목록 조회
+    List<BoothExperienceReservation> findByExperienceStatusCode(BoothExperienceStatusCode statusCode);
+
+    // 체험별 특정 상태 예약 목록 조회
+    List<BoothExperienceReservation> findByBoothExperienceAndExperienceStatusCode(
+            BoothExperience boothExperience, BoothExperienceStatusCode statusCode);
+
+    // 사용자의 특정 체험 예약 조회 (중복 예약 체크용)
+    Optional<BoothExperienceReservation> findByBoothExperienceAndUser(BoothExperience boothExperience, Users user);
+
+    // 사용자의 활성 예약 조회 (취소되지 않은 예약)
+    @Query("SELECT ber FROM BoothExperienceReservation ber WHERE ber.user = :user " +
+           "AND ber.experienceStatusCode.code != 'CANCELLED' AND ber.experienceStatusCode.code != 'COMPLETED'")
+    List<BoothExperienceReservation> findActiveReservationsByUser(@Param("user") Users user);
+
+    // 체험별 대기중인 예약 목록 (대기 순서대로)
+    @Query("SELECT ber FROM BoothExperienceReservation ber WHERE ber.boothExperience = :experience " +
+           "AND ber.experienceStatusCode.code IN ('WAITING', 'READY') ORDER BY ber.queuePosition ASC")
+    List<BoothExperienceReservation> findWaitingReservations(@Param("experience") BoothExperience experience);
+
+    // 체험별 현재 체험중인 예약 목록
+    @Query("SELECT ber FROM BoothExperienceReservation ber WHERE ber.boothExperience = :experience " +
+           "AND ber.experienceStatusCode.code = 'IN_PROGRESS'")
+    List<BoothExperienceReservation> findInProgressReservations(@Param("experience") BoothExperience experience);
+
+    // 다음 대기 순번 조회
+    @Query("SELECT COALESCE(MAX(ber.queuePosition), 0) + 1 FROM BoothExperienceReservation ber " +
+           "WHERE ber.boothExperience = :experience AND ber.experienceStatusCode.code IN ('WAITING', 'READY')")
+    Integer findNextQueuePosition(@Param("experience") BoothExperience experience);
+
+    // 사용자별 특정 이벤트 예약 목록
+    @Query("SELECT ber FROM BoothExperienceReservation ber WHERE ber.user = :user " +
+           "AND ber.boothExperience.booth.event.eventId = :eventId ORDER BY ber.reservedAt DESC")
+    List<BoothExperienceReservation> findByUserAndEventId(@Param("user") Users user, @Param("eventId") Long eventId);
+}

--- a/src/main/java/com/fairing/fairplay/booth/repository/BoothExperienceStatusCodeRepository.java
+++ b/src/main/java/com/fairing/fairplay/booth/repository/BoothExperienceStatusCodeRepository.java
@@ -1,0 +1,14 @@
+package com.fairing.fairplay.booth.repository;
+
+import com.fairing.fairplay.booth.entity.BoothExperienceStatusCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BoothExperienceStatusCodeRepository extends JpaRepository<BoothExperienceStatusCode, Integer> {
+
+    // 상태 코드로 조회
+    Optional<BoothExperienceStatusCode> findByCode(String code);
+}

--- a/src/main/java/com/fairing/fairplay/booth/service/BoothExperienceService.java
+++ b/src/main/java/com/fairing/fairplay/booth/service/BoothExperienceService.java
@@ -1,0 +1,295 @@
+package com.fairing.fairplay.booth.service;
+
+import com.fairing.fairplay.booth.dto.*;
+import com.fairing.fairplay.booth.entity.Booth;
+import com.fairing.fairplay.booth.entity.BoothExperience;
+import com.fairing.fairplay.booth.entity.BoothExperienceReservation;
+import com.fairing.fairplay.booth.entity.BoothExperienceStatusCode;
+import com.fairing.fairplay.booth.repository.BoothExperienceRepository;
+import com.fairing.fairplay.booth.repository.BoothExperienceReservationRepository;
+import com.fairing.fairplay.booth.repository.BoothExperienceStatusCodeRepository;
+import com.fairing.fairplay.booth.repository.BoothRepository;
+import com.fairing.fairplay.user.entity.Users;
+import com.fairing.fairplay.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BoothExperienceService {
+
+    private final BoothExperienceRepository boothExperienceRepository;
+    private final BoothExperienceReservationRepository reservationRepository;
+    private final BoothExperienceStatusCodeRepository statusCodeRepository;
+    private final BoothRepository boothRepository;
+    private final UserRepository userRepository;
+
+    // 1. 부스 체험 등록 (부스 담당자)
+    @Transactional
+    public BoothExperienceResponseDto createBoothExperience(Long boothId, BoothExperienceRequestDto requestDto) {
+        log.info("부스 체험 등록 시작 - 부스 ID: {}", boothId);
+
+        Booth booth = boothRepository.findById(boothId)
+                .orElseThrow(() -> new IllegalArgumentException("부스를 찾을 수 없습니다: " + boothId));
+
+        BoothExperience experience = BoothExperience.builder()
+                .booth(booth)
+                .title(requestDto.getTitle())
+                .description(requestDto.getDescription())
+                .experienceDate(requestDto.getExperienceDate())
+                .startTime(requestDto.getStartTime())
+                .endTime(requestDto.getEndTime())
+                .durationMinutes(requestDto.getDurationMinutes())
+                .maxCapacity(requestDto.getMaxCapacity())
+                .allowWaiting(requestDto.getAllowWaiting() != null ? requestDto.getAllowWaiting() : true)
+                .maxWaitingCount(requestDto.getMaxWaitingCount())
+                .allowDuplicateReservation(requestDto.getAllowDuplicateReservation() != null ? 
+                        requestDto.getAllowDuplicateReservation() : false)
+                .isReservationEnabled(requestDto.getIsReservationEnabled() != null ? 
+                        requestDto.getIsReservationEnabled() : true)
+                .build();
+
+        BoothExperience savedExperience = boothExperienceRepository.save(experience);
+        log.info("부스 체험 등록 완료 - 체험 ID: {}", savedExperience.getExperienceId());
+
+        return BoothExperienceResponseDto.fromEntity(savedExperience);
+    }
+
+    // 2. 부스 체험 목록 조회 (부스 담당자용)
+    @Transactional(readOnly = true)
+    public List<BoothExperienceResponseDto> getBoothExperiences(Long boothId) {
+        List<BoothExperience> experiences = boothExperienceRepository.findByBooth_Id(boothId);
+        return experiences.stream()
+                .map(BoothExperienceResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    // 3. 체험 가능한 부스 체험 목록 조회 (참여자용)
+    @Transactional(readOnly = true)
+    public List<BoothExperienceResponseDto> getAvailableExperiences() {
+        LocalDate today = LocalDate.now();
+        List<BoothExperience> experiences = boothExperienceRepository.findAvailableExperiences(today);
+        return experiences.stream()
+                .map(BoothExperienceResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    // 4. 부스 체험 예약 신청 (참여자) - 동시성 처리
+    @Transactional
+    public BoothExperienceReservationResponseDto createReservation(Long experienceId, Long userId, 
+                                                                  BoothExperienceReservationRequestDto requestDto) {
+        log.info("부스 체험 예약 시작 - 체험 ID: {}, 사용자 ID: {}", experienceId, userId);
+
+        BoothExperience experience = boothExperienceRepository.findById(experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("체험을 찾을 수 없습니다: " + experienceId));
+
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + userId));
+
+        // 예약 가능 여부 검증
+        validateReservationRequest(experience, user);
+
+        // 대기중 상태 코드 조회
+        BoothExperienceStatusCode waitingStatus = statusCodeRepository.findByCode("WAITING")
+                .orElseThrow(() -> new IllegalStateException("대기 상태 코드를 찾을 수 없습니다"));
+
+        // 다음 대기 순번 조회 (동시성 처리)
+        Integer nextPosition = reservationRepository.findNextQueuePosition(experience);
+
+        BoothExperienceReservation reservation = BoothExperienceReservation.builder()
+                .boothExperience(experience)
+                .user(user)
+                .experienceStatusCode(waitingStatus)
+                .queuePosition(nextPosition)
+                .notes(requestDto.getNotes())
+                .build();
+
+        BoothExperienceReservation savedReservation = reservationRepository.save(reservation);
+        log.info("부스 체험 예약 완료 - 예약 ID: {}, 대기 순번: {}", 
+                savedReservation.getReservationId(), savedReservation.getQueuePosition());
+
+        return BoothExperienceReservationResponseDto.fromEntity(savedReservation);
+    }
+
+    // 5. 부스 체험 예약자 목록 조회 (부스 담당자용)
+    @Transactional(readOnly = true)
+    public List<BoothExperienceReservationResponseDto> getExperienceReservations(Long experienceId) {
+        BoothExperience experience = boothExperienceRepository.findById(experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("체험을 찾을 수 없습니다: " + experienceId));
+
+        List<BoothExperienceReservation> reservations = 
+                reservationRepository.findByBoothExperienceOrderByReservedAt(experience);
+
+        return reservations.stream()
+                .map(BoothExperienceReservationResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    // 6. 내 부스 체험 예약 목록 조회 (참여자용)
+    @Transactional(readOnly = true)
+    public List<BoothExperienceReservationResponseDto> getMyReservations(Long userId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + userId));
+
+        List<BoothExperienceReservation> reservations = reservationRepository.findByUserOrderByReservedAtDesc(user);
+        return reservations.stream()
+                .map(BoothExperienceReservationResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    // 7. 부스 체험 상태 변경 (부스 담당자)
+    @Transactional
+    public BoothExperienceReservationResponseDto updateReservationStatus(Long reservationId, 
+                                                                        BoothExperienceStatusUpdateDto updateDto) {
+        log.info("예약 상태 변경 시작 - 예약 ID: {}, 새 상태: {}", reservationId, updateDto.getStatusCode());
+
+        BoothExperienceReservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다: " + reservationId));
+
+        BoothExperienceStatusCode newStatus = statusCodeRepository.findByCode(updateDto.getStatusCode())
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 상태 코드입니다: " + updateDto.getStatusCode()));
+
+        // 상태 변경 유효성 검증
+        validateStatusChange(reservation, newStatus);
+
+        // 상태 변경 처리
+        processStatusChange(reservation, newStatus, updateDto.getNotes());
+
+        BoothExperienceReservation updatedReservation = reservationRepository.save(reservation);
+        log.info("예약 상태 변경 완료 - 예약 ID: {}, 상태: {}", reservationId, newStatus.getCode());
+
+        return BoothExperienceReservationResponseDto.fromEntity(updatedReservation);
+    }
+
+    // 예약 요청 유효성 검증
+    private void validateReservationRequest(BoothExperience experience, Users user) {
+        // 예약 활성화 여부 확인
+        if (!experience.getIsReservationEnabled()) {
+            throw new IllegalStateException("현재 예약이 비활성화되어 있습니다.");
+        }
+
+        // 예약 가능 여부 확인
+        if (!experience.isReservationAvailable()) {
+            throw new IllegalStateException("현재 예약이 불가능합니다. 대기열이 가득참.");
+        }
+
+        // 중복 예약 방지
+        if (!experience.getAllowDuplicateReservation()) {
+            reservationRepository.findByBoothExperienceAndUser(experience, user)
+                    .ifPresent(existing -> {
+                        if (existing.isActive()) {
+                            throw new IllegalStateException("이미 예약하신 체험입니다.");
+                        }
+                    });
+        }
+    }
+
+    // 상태 변경 유효성 검증
+    private void validateStatusChange(BoothExperienceReservation reservation, BoothExperienceStatusCode newStatus) {
+        String currentStatus = reservation.getExperienceStatusCode().getCode();
+        String targetStatus = newStatus.getCode();
+
+        // 상태 전환 규칙 검증
+        switch (currentStatus) {
+            case "WAITING":
+                if (!"READY".equals(targetStatus) && !"CANCELLED".equals(targetStatus)) {
+                    throw new IllegalArgumentException("대기중 상태에서는 입장가능 또는 취소 상태로만 변경 가능합니다.");
+                }
+                break;
+            case "READY":
+                if (!"IN_PROGRESS".equals(targetStatus) && !"CANCELLED".equals(targetStatus)) {
+                    throw new IllegalArgumentException("입장가능 상태에서는 체험중 또는 취소 상태로만 변경 가능합니다.");
+                }
+                break;
+            case "IN_PROGRESS":
+                if (!"COMPLETED".equals(targetStatus)) {
+                    throw new IllegalArgumentException("체험중 상태에서는 완료 상태로만 변경 가능합니다.");
+                }
+                break;
+            case "COMPLETED":
+            case "CANCELLED":
+                throw new IllegalArgumentException("완료 또는 취소된 예약의 상태는 변경할 수 없습니다.");
+        }
+
+        // 최대 수용 인원 확인 (IN_PROGRESS로 변경 시)
+        if ("IN_PROGRESS".equals(targetStatus)) {
+            BoothExperience experience = reservation.getBoothExperience();
+            int currentParticipants = experience.getCurrentParticipants();
+            if (currentParticipants >= experience.getMaxCapacity()) {
+                throw new IllegalStateException("최대 수용 인원을 초과했습니다.");
+            }
+        }
+    }
+
+    // 상태 변경 처리
+    private void processStatusChange(BoothExperienceReservation reservation, 
+                                   BoothExperienceStatusCode newStatus, String notes) {
+        LocalDateTime now = LocalDateTime.now();
+        reservation.setExperienceStatusCode(newStatus);
+        
+        if (notes != null && !notes.trim().isEmpty()) {
+            reservation.setNotes(notes);
+        }
+
+        switch (newStatus.getCode()) {
+            case "READY":
+                reservation.setReadyAt(now);
+                break;
+            case "IN_PROGRESS":
+                reservation.setStartedAt(now);
+                // 다음 대기자를 READY 상태로 변경
+                processNextWaitingReservation(reservation.getBoothExperience());
+                break;
+            case "COMPLETED":
+                reservation.setCompletedAt(now);
+                // 다음 대기자를 READY 상태로 변경
+                processNextWaitingReservation(reservation.getBoothExperience());
+                break;
+            case "CANCELLED":
+                reservation.setCancelledAt(now);
+                // 대기 순번 재정렬
+                reorderQueuePositions(reservation.getBoothExperience());
+                break;
+        }
+    }
+
+    // 다음 대기자를 READY 상태로 변경
+    private void processNextWaitingReservation(BoothExperience experience) {
+        List<BoothExperienceReservation> waitingReservations = 
+                reservationRepository.findWaitingReservations(experience);
+
+        if (!waitingReservations.isEmpty()) {
+            BoothExperienceReservation nextReservation = waitingReservations.get(0);
+            BoothExperienceStatusCode readyStatus = statusCodeRepository.findByCode("READY")
+                    .orElseThrow(() -> new IllegalStateException("준비 상태 코드를 찾을 수 없습니다"));
+
+            nextReservation.setExperienceStatusCode(readyStatus);
+            nextReservation.setReadyAt(LocalDateTime.now());
+            reservationRepository.save(nextReservation);
+            
+            log.info("다음 대기자 호출 - 예약 ID: {}", nextReservation.getReservationId());
+        }
+    }
+
+    // 대기 순번 재정렬 (취소 시)
+    private void reorderQueuePositions(BoothExperience experience) {
+        List<BoothExperienceReservation> waitingReservations = 
+                reservationRepository.findWaitingReservations(experience);
+
+        for (int i = 0; i < waitingReservations.size(); i++) {
+            BoothExperienceReservation reservation = waitingReservations.get(i);
+            reservation.setQueuePosition(i + 1);
+        }
+
+        reservationRepository.saveAll(waitingReservations);
+        log.info("대기 순번 재정렬 완료 - 체험 ID: {}", experience.getExperienceId());
+    }
+}


### PR DESCRIPTION
[ 부스 관리자 ]
- 부스 체험 등록
- 부스 체험 등록한 목록 조회
- 부스 체험 예약자 목록 조회
- 예약자 체험 상태 변경

[ 참가자 ]
- 체험가능한 부스 체험 목록 조회
- 부스 체험 예약 신청
- 내 부스 체험 예약 신청 목록 조회

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 부스 체험 관리 및 예약 시스템이 도입되었습니다.
  * 부스 매니저는 부스 체험을 등록하고, 체험별 예약 현황을 조회 및 관리할 수 있습니다.
  * 참가자는 체험 목록 조회, 예약 생성, 내 예약 내역 확인, 예약 취소가 가능합니다.
  * 예약 상태(대기, 준비, 진행, 완료, 취소) 변경 및 대기열 현황 확인 기능이 추가되었습니다.
  * 예약 생성 시 동시성 제어를 통한 대기열 순서 관리가 적용되었습니다.
  * 사용자 회원가입, 중복 확인, 로그인 API 테스트 스크립트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->