### PR TITLE
refactor: 참석자 및 공유폼 관련 api 테스트 완료

### DIFF
--- a/src/main/http/attendee.http
+++ b/src/main/http/attendee.http
@@ -8,7 +8,7 @@ POST http://localhost:8080/api/attendees?token={{token}}
 Content-Type: application/json
 
 {
-  "name": "2테스트2",
+  "name": "22테스트22",
   "email": "khyeon2021@kyonggi.ac.kr",
   "phone": "010-12345-5678",
   "birth": null
@@ -21,7 +21,11 @@ Content-Type: application/json
 
 {
   "reservationId": 2,
-  "name": "1테스트",
+  "name": "11수정11",
   "email": "khyeon2020@naver.com",
   "phone": "010-1111-3333"
 }
+
+### 행사별 참석자 전체 조회
+@eventId = 1
+GET http://localhost:8080/api/attendees/events/{{eventId}}

--- a/src/main/java/com/fairing/fairplay/attendee/controller/AttendeeController.java
+++ b/src/main/java/com/fairing/fairplay/attendee/controller/AttendeeController.java
@@ -4,7 +4,6 @@ import com.fairing.fairplay.attendee.dto.AttendeeInfoResponseDto;
 import com.fairing.fairplay.attendee.dto.AttendeeListInfoResponseDto;
 import com.fairing.fairplay.attendee.dto.AttendeeSaveRequestDto;
 import com.fairing.fairplay.attendee.dto.AttendeeUpdateRequestDto;
-import com.fairing.fairplay.attendee.entity.Attendee;
 import com.fairing.fairplay.attendee.service.AttendeeService;
 
 import com.fairing.fairplay.core.security.CustomUserDetails;
@@ -58,19 +57,8 @@ public class AttendeeController {
   @GetMapping("/events/{eventId}")
   public ResponseEntity<List<AttendeeInfoResponseDto>> getAttendees(@PathVariable Long eventId,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
-    List<Attendee> attendees = attendeeService.getAttendeesByEvent(eventId,
+    List<AttendeeInfoResponseDto> response = attendeeService.getAttendeesByEvent(eventId,
         userDetails.getUserId());
-
-    List<AttendeeInfoResponseDto> response = attendees.stream()
-        .map(attendee -> AttendeeInfoResponseDto.builder()
-            .attendeeId(attendee.getId())
-            .reservationId(attendee.getReservation().getReservationId())
-            .name(attendee.getName())
-            .email(attendee.getEmail())
-            .phone(attendee.getPhone())
-            .build())
-        .toList();
-
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/fairing/fairplay/attendee/controller/AttendeeController.java
+++ b/src/main/java/com/fairing/fairplay/attendee/controller/AttendeeController.java
@@ -58,7 +58,7 @@ public class AttendeeController {
   public ResponseEntity<List<AttendeeInfoResponseDto>> getAttendees(@PathVariable Long eventId,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     List<AttendeeInfoResponseDto> response = attendeeService.getAttendeesByEvent(eventId,
-        userDetails.getUserId());
+        userDetails);
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/fairing/fairplay/attendee/dto/AttendeeListInfoResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/attendee/dto/AttendeeListInfoResponseDto.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class AttendeeListInfoResponseDto {
+
   private Long reservationId;
   private List<AttendeeInfoResponseDto> attendees;
 }

--- a/src/main/java/com/fairing/fairplay/attendee/repository/AttendeeRepository.java
+++ b/src/main/java/com/fairing/fairplay/attendee/repository/AttendeeRepository.java
@@ -25,6 +25,7 @@ public interface AttendeeRepository extends JpaRepository<Attendee, Long> {
         JOIN a.reservation r
         JOIN r.event e
         WHERE e.eventId = :eventId
+        ORDER BY a.createdAt ASC
     """)
   List<Attendee> findByEventId(Long eventId);
 }

--- a/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
+++ b/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
@@ -62,12 +62,7 @@ public class AttendeeService {
         reservationId);
 
     List<AttendeeInfoResponseDto> result = attendees.stream()
-        .map(attendee -> AttendeeInfoResponseDto.builder()
-            .attendeeId(attendee.getId())
-            .name(attendee.getName())
-            .email(attendee.getEmail())
-            .phone(attendee.getPhone())
-            .build())
+        .map(this::buildAttendeeInfoResponse)
         .toList();
 
     return AttendeeListInfoResponseDto.builder()
@@ -85,18 +80,18 @@ public class AttendeeService {
     // 예약 있는지 조회
     Reservation reservation = findReservation(dto.getReservationId());
 
-    // 대표자와 현재 수정 요청한 요청자의 ID 비교
-    if (!Objects.equals(reservation.getUser().getUserId(), userId)) {
-      throw new CustomException(HttpStatus.FORBIDDEN, "현재 사용자와 티켓 소유주가 일치하지 않습니다.");
-    }
-
     // 참석자 정보 조회 -> 예약ID + 참석자ID
     Attendee attendee = attendeeRepository.findByIdAndReservation_ReservationId(attendeeId,
             reservation.getReservationId())
         .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "참석자 정보를 조회할 수 없습니다."));
 
+    // 대표자와 현재 수정 요청한 요청자의 ID 비교
+    if (!Objects.equals(reservation.getUser().getUserId(), userId)) {
+      throw new CustomException(HttpStatus.FORBIDDEN, "현재 사용자와 티켓 소유주가 일치하지 않습니다.");
+    }
+
     // 수정하려는 정보가 대표자일 경우 수정 불가하므로 예외 발생
-    if ("PRIMARY".equals(attendee.getAttendeeTypeCode().getCode().trim())) {
+    if (AttendeeTypeCode.PRIMARY.equals(attendee.getAttendeeTypeCode().getCode().trim())) {
       throw new CustomException(HttpStatus.BAD_REQUEST, "대표자 정보는 수정할 수 없습니다.");
     }
 
@@ -105,32 +100,29 @@ public class AttendeeService {
     attendee.setPhone(dto.getPhone());
     attendee.setName(dto.getName());
 
-    return AttendeeInfoResponseDto.builder()
-        .attendeeId(attendee.getId())
-        .reservationId(attendee.getReservation().getReservationId())
-        .name(attendee.getName())
-        .email(attendee.getEmail())
-        .phone(attendee.getPhone())
-        .build();
+    return buildAttendeeInfoResponse(attendee);
   }
 
   // 행사별 예약자 명단 조회 (행사 관리자)
-  public List<Attendee> getAttendeesByEvent(Long eventId, Long userId) {
+  public List<AttendeeInfoResponseDto> getAttendeesByEvent(Long eventId, Long userId) {
     // eventId 유효성 검사
     if (eventId == null || eventId <= 0) {
       throw new CustomException(HttpStatus.BAD_REQUEST, "유효하지 않은 행사 ID입니다.");
     }
 
     // 행사 관리자 권한 검증
-
-    return attendeeRepository.findByEventId(eventId);
+    List<Attendee> attendees =  attendeeRepository.findByEventId(eventId);
+    return attendees.stream()
+        .map(this::buildAttendeeInfoResponse)
+        .toList();
   }
 
   // DB save 로직 분리
   private AttendeeInfoResponseDto saveAttendee(String attendeeType, AttendeeSaveRequestDto dto,
       Long reservationId) {
     AttendeeTypeCode attendeeTypeCode = attendeeTypeCodeRepository.findByCode(attendeeType)
-        .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST,"잘못된 참석자 유형 값입니다. 입력값: "+attendeeType));
+        .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST,
+            "잘못된 참석자 유형 값입니다. 입력값: " + attendeeType));
 
     Reservation reservation = findReservation(reservationId);
 
@@ -142,12 +134,16 @@ public class AttendeeService {
         .reservation(reservation)
         .build();
     Attendee savedAttendee = attendeeRepository.save(attendee);
+    return buildAttendeeInfoResponse(savedAttendee);
+  }
+
+  private AttendeeInfoResponseDto buildAttendeeInfoResponse(Attendee attendee) {
     return AttendeeInfoResponseDto.builder()
-        .attendeeId(savedAttendee.getId())
-        .reservationId(savedAttendee.getReservation().getReservationId())
-        .name(savedAttendee.getName())
-        .email(savedAttendee.getEmail())
-        .phone(savedAttendee.getPhone())
+        .attendeeId(attendee.getId())
+        .reservationId(attendee.getReservation().getReservationId())
+        .name(attendee.getName())
+        .email(attendee.getEmail())
+        .phone(attendee.getPhone())
         .build();
   }
 

--- a/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
+++ b/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
@@ -14,6 +14,7 @@ import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.reservation.repository.ReservationRepository;
 import com.fairing.fairplay.shareticket.entity.ShareTicket;
 import com.fairing.fairplay.shareticket.service.ShareTicketService;
+
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -104,14 +105,18 @@ public class AttendeeService {
   }
 
   // 행사별 예약자 명단 조회 (행사 관리자)
-  public List<AttendeeInfoResponseDto> getAttendeesByEvent(Long eventId, Long userId) {
+  public List<AttendeeInfoResponseDto> getAttendeesByEvent(Long eventId,
+      CustomUserDetails userDetails) {
+    // 행사 관리자 권한 검증
+    if ("COMMON".equals(userDetails.getRoleCode())) {
+      throw new CustomException(HttpStatus.FORBIDDEN, "행사별 예약자 명단을 조회할 권한이 없습니다.");
+    }
     // eventId 유효성 검사
     if (eventId == null || eventId <= 0) {
       throw new CustomException(HttpStatus.BAD_REQUEST, "유효하지 않은 행사 ID입니다.");
     }
 
-    // 행사 관리자 권한 검증
-    List<Attendee> attendees =  attendeeRepository.findByEventId(eventId);
+    List<Attendee> attendees = attendeeRepository.findByEventId(eventId);
     return attendees.stream()
         .map(this::buildAttendeeInfoResponse)
         .toList();

--- a/src/main/java/com/fairing/fairplay/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/fairing/fairplay/payment/repository/PaymentRepository.java
@@ -15,4 +15,6 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     List<Payment> findByEvent_EventId(Long eventId);
 
     List<Payment> findByUser_UserId(Long userId);
+
+    Optional<Payment> findByTargetIdAndPaymentTargetType_PaymentTargetCode(Long targetId, String paymentTargetType);
 }

--- a/src/main/java/com/fairing/fairplay/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/fairing/fairplay/payment/repository/PaymentRepository.java
@@ -16,5 +16,5 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     List<Payment> findByUser_UserId(Long userId);
 
-    Optional<Payment> findByTargetIdAndPaymentTargetType_PaymentTargetCode(Long targetId, String paymentTargetType);
+    boolean existsByTargetIdAndPaymentTargetType_PaymentTargetCodeAndPaymentStatusCode_Code(Long targetId, String paymentTargetType, String paymentStatusCode);
 }

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
@@ -107,7 +107,7 @@ public class QrTicketBatchService {
 
           log.info("[QrTicketInitProvider] List<Tuple> results - e: {}", e.getTitleKr());
 
-          LocalDateTime expiredAt = LocalDateTime.of(es.getDate(), es.getEndTime()); //만료시간 설정
+          LocalDateTime expiredAt = LocalDateTime.of(es.getDate(), es.getEndTime()); //만료날짜+시간 설정
           String ticketNo = codeGenerator.generateTicketNo(eventCode); // 티켓번호 설정
 
           return QrTicket.builder()

--- a/src/main/java/com/fairing/fairplay/shareticket/dto/ShareTicketSaveRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/dto/ShareTicketSaveRequestDto.java
@@ -1,6 +1,5 @@
 package com.fairing.fairplay.shareticket.dto;
 
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,5 +13,4 @@ public class ShareTicketSaveRequestDto {
 
   private Long reservationId; // 예약ID
   private Integer totalAllowed; // 구매한 티켓 총 개수
-  private LocalDateTime expiredAt; // 만료 날짜 (행사 시작일 or 티켓 사용일 -1)
 }

--- a/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketBatchService.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketBatchService.java
@@ -25,9 +25,9 @@ public class ShareTicketBatchService {
   public List<ShareTicket> fetchExpiredBatch(int page, int size) {
     Pageable pageable = PageRequest.of(page, size);
 
-    LocalDate now = LocalDate.now(); // 2025-08-06
+    LocalDate now = LocalDate.now(); // 2025-08-10
     LocalDateTime startDate = now.atStartOfDay();
-    LocalDateTime endDate = now.plusDays(1).atStartOfDay();
+    LocalDateTime endDate = now.plusDays(1).atStartOfDay(); // 11
     log.info("fetchExpiredBatch startDate: {}, endDate: {}", startDate, endDate);
 
     return shareTicketRepository.findAllByExpiredAtGreaterThanEqualAndExpiredAtLessThan(

--- a/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketService.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketService.java
@@ -2,12 +2,16 @@ package com.fairing.fairplay.shareticket.service;
 
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.common.exception.LinkExpiredException;
+import com.fairing.fairplay.payment.entity.Payment;
+
+import com.fairing.fairplay.payment.repository.PaymentRepository;
 import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.reservation.repository.ReservationRepository;
 import com.fairing.fairplay.shareticket.dto.ShareTicketSaveRequestDto;
 import com.fairing.fairplay.shareticket.entity.ShareTicket;
 import com.fairing.fairplay.shareticket.repository.ShareTicketRepository;
 import java.nio.ByteBuffer;
+
 import java.util.Base64;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +27,10 @@ public class ShareTicketService {
 
   private final ShareTicketRepository shareTicketRepository;
   private final ReservationRepository reservationRepository;
+  private final PaymentRepository paymentRepository;
 
+  private static final String RESERVATION = "RESERVATION";
+  private static final String COMPLETED = "COMPLETED";
   // 공유 폼 링크 생성 -> 예약 성공 시 예약 서비스 단계에서 사용
   @Transactional
   public String generateToken(ShareTicketSaveRequestDto dto) {
@@ -34,6 +41,17 @@ public class ShareTicketService {
     // 예약 유무 조회
     Reservation reservation = reservationRepository.findById(dto.getReservationId())
         .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "예약을 찾을 수 없습니다."));
+
+    // 결제 내역 조회
+    Payment payment = paymentRepository.findByTargetIdAndPaymentTargetType_PaymentTargetCode(
+        reservation.getReservationId(), RESERVATION).orElseThrow(
+        () -> new CustomException(HttpStatus.NOT_FOUND, "결제 내역을 찾을 수 없습니다.")
+    );
+
+    // 정상적으로 결제 처리된 예약인지 조회
+    if (!payment.getPaymentStatusCode().getCode().equals(COMPLETED)) {
+      throw new CustomException(HttpStatus.BAD_REQUEST, "결제가 정상적으로 처리되지 않았습니다.");
+    }
 
     // 예약 ID 기준 폼이 생성되어있는지 조회
     if (shareTicketRepository.existsByReservation_ReservationId(dto.getReservationId())) {
@@ -52,7 +70,7 @@ public class ShareTicketService {
     } while (shareTicketRepository.existsByLinkToken(token));
 
     if (dto.getTotalAllowed() == null || dto.getTotalAllowed() <= 0) {
-      throw new IllegalArgumentException("허용 인원은 1명 이상이어야 합니다.");
+      throw new CustomException(HttpStatus.BAD_REQUEST,"허용 인원은 1명 이상이어야 합니다.");
     }
 
     ShareTicket shareTicket = ShareTicket.builder()
@@ -61,7 +79,8 @@ public class ShareTicketService {
         .expired(false) // 만료 여부
         .submittedCount(1) // 대표자 제출
         .reservation(reservation) // 예약 연결
-        .expiredAt(dto.getExpiredAt()) // 폼 만료 기한 (행사 시작일 or 티켓 사용일 -1)
+        .expiredAt(reservation.getSchedule().getDate().minusDays(1)
+            .atStartOfDay()) // 폼 만료 기한 (행사 시작일 하루 전)
         .build();
 
     shareTicketRepository.save(shareTicket);
@@ -71,7 +90,7 @@ public class ShareTicketService {
   // 공유폼 token 유효성 검사
   public ShareTicket validateAndUseToken(String token) {
     ShareTicket shareTicket = shareTicketRepository.findByLinkToken(token)
-        .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND,"요청하신 링크를 찾을 수 없습니다."));
+        .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "요청하신 링크를 찾을 수 없습니다."));
 
     // 만료된 링크 (행사시작 1일전)
     if (shareTicket.getExpired()) {


### PR DESCRIPTION
## 변경 사항
- 예외처리 추가
- 코드 리팩토링

## 관련 이슈
#36  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 이벤트 ID로 모든 참가자를 조회하는 새로운 API 예시가 추가되었습니다.

* **버그 수정**
  * 공유 티켓 생성 시 결제 완료 상태가 아닌 경우 링크를 생성할 수 없도록 검증이 추가되었습니다.
  * 공유 티켓 만료일이 예약 일정 하루 전으로 자동 설정됩니다.
  * 공유 티켓 생성 시 허용 인원(totalAllowed)이 0 이하일 경우 적절한 예외가 반환됩니다.

* **기능 개선**
  * 참가자 목록 조회 시 결과가 생성일 기준 오름차순으로 정렬됩니다.
  * 참가자 목록 조회 API 응답이 더 간결한 형태로 개선되었습니다.

* **불필요한 필드/코드 제거**
  * 공유 티켓 요청 DTO에서 만료일(expiredAt) 필드가 제거되었습니다.

* **문서**
  * HTTP 요청 예시의 샘플 데이터가 일부 수정되었습니다.
  * 주석이 일부 명확하게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->