### PR TITLE
refactor: QR 코드 관련 로그 로직 수정

### DIFF
--- a/src/main/http/qrticket.http
+++ b/src/main/http/qrticket.http
@@ -38,3 +38,39 @@ Content-Type: application/json
   "attendeeId": 2,
   "ticketNo": "EVT202408A-20250806-0002"
 }
+
+### 회원 QR 스캔 입장
+POST http://localhost:8080/api/qr-tickets/check-in/member/qr
+Content-Type: application/json
+
+{
+ "reservationId": 1,
+  "qrCode": "asdf"
+}
+
+### 회원 수동코드 스캔 입장
+POST http://localhost:8080/api/qr-tickets/check-in/member/manual
+Content-Type: application/json
+
+{
+  "reservationId": 1,
+  "manualCode": "asdf"
+}
+
+### 비회원 QR 스캔 입장
+POST http://localhost:8080/api/qr-tickets/check-in/guest/qr
+Content-Type: application/json
+
+{
+  "qrLinkToken": "dddd",
+  "qrCode": "asdf"
+}
+
+### 비회원 수동코드 스캔 입장
+POST http://localhost:8080/api/qr-tickets/check-in/guest/manual
+Content-Type: application/json
+
+{
+  "qrLinkToken": "dddd",
+  "manualCode": "asdf"
+}

--- a/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
+++ b/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
@@ -78,7 +78,6 @@ public class QrTicketController {
    * 2. 회원+수동
    * 3. 비회원+QR
    * 4. 비회원+수동
-   *
    */
 
   // 체크인 1

--- a/src/main/java/com/fairing/fairplay/qr/dto/CheckInRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/qr/dto/CheckInRequestDto.java
@@ -18,6 +18,6 @@ public class CheckInRequestDto {
   private String codeValue;// qr 또는 manual 실제 값
   private String codeType;// QR or MANUAL
   boolean requireUserMatch;// 회원 체크인일때 참석자=로그인정보 일치하는지 여부 조회
-  CustomUserDetails userDetails;// 회원
-  String qrActionCode; // CHECKED_IN, MANUAL_CHECKED_IN
+  private CustomUserDetails userDetails;// 회원
+  private String qrActionCode; // CHECKED_IN, MANUAL_CHECKED_IN
 }

--- a/src/main/java/com/fairing/fairplay/qr/dto/CheckInRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/qr/dto/CheckInRequestDto.java
@@ -17,7 +17,7 @@ public class CheckInRequestDto {
   private Attendee attendee;//회원
   private String codeValue;// qr 또는 manual 실제 값
   private String codeType;// QR or MANUAL
-  boolean requireUserMatch;// 회원 체크인일때 참석자=로그인정보 일치하는지 여부 조회
+  private boolean requireUserMatch;// 회원 체크인일때 참석자=로그인정보 일치하는지 여부 조회
   private CustomUserDetails userDetails;// 회원
   private String qrActionCode; // CHECKED_IN, MANUAL_CHECKED_IN
 }

--- a/src/main/java/com/fairing/fairplay/qr/dto/CheckInRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/qr/dto/CheckInRequestDto.java
@@ -1,0 +1,23 @@
+package com.fairing.fairplay.qr.dto;
+
+import com.fairing.fairplay.attendee.entity.Attendee;
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CheckInRequestDto {
+  private Attendee attendee;//회원
+  private String codeValue;// qr 또는 manual 실제 값
+  private String codeType;// QR or MANUAL
+  boolean requireUserMatch;// 회원 체크인일때 참석자=로그인정보 일치하는지 여부 조회
+  CustomUserDetails userDetails;// 회원
+  String qrActionCode; // CHECKED_IN, MANUAL_CHECKED_IN
+}

--- a/src/main/java/com/fairing/fairplay/qr/dto/EntryPolicyDto.java
+++ b/src/main/java/com/fairing/fairplay/qr/dto/EntryPolicyDto.java
@@ -1,0 +1,19 @@
+package com.fairing.fairplay.qr.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EntryPolicyDto {
+
+  private Boolean checkInAllowed;
+  private Boolean checkOutAllowed;
+  private Boolean reentryAllowed;
+}

--- a/src/main/java/com/fairing/fairplay/qr/dto/EntryPolicyDto.java
+++ b/src/main/java/com/fairing/fairplay/qr/dto/EntryPolicyDto.java
@@ -4,16 +4,17 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class EntryPolicyDto {
 
-  private Boolean checkInAllowed;
-  private Boolean checkOutAllowed;
-  private Boolean reentryAllowed;
+  @Builder.Default
+  private boolean checkInAllowed = false;
+  @Builder.Default
+  private boolean checkOutAllowed = false;
+  @Builder.Default
+  private boolean reentryAllowed = false;
 }

--- a/src/main/java/com/fairing/fairplay/qr/repository/QrLogRepository.java
+++ b/src/main/java/com/fairing/fairplay/qr/repository/QrLogRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface QrLogRepository extends JpaRepository<QrLog, Long> {
   Optional<QrLog> findByActionCode_Code(String qrActionCode);
 
-  boolean existsByQrTicketAndActionCode_Code(QrTicket qrTicket, String qrActionCode);
+  Optional<QrLog> findTop1ByQrTicketAndActionCode_CodeOrderByCreatedAtDesc(QrTicket qrTicket, String qrActionCode);
 }

--- a/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
@@ -3,7 +3,9 @@ package com.fairing.fairplay.qr.repository;
 import com.fairing.fairplay.attendee.entity.Attendee;
 import com.fairing.fairplay.qr.dto.QrTicketResponseDto;
 import com.fairing.fairplay.qr.entity.QrTicket;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -30,7 +32,9 @@ public interface QrTicketRepository extends JpaRepository<QrTicket, Long> {
 
   Optional<QrTicket> findByTicketNo(String ticketNo);
 
-  @Query("select qt from QrTicket qt join qt.attendee a where a.id = :attendeeId and a.reservation.reservationId = :reservationId")
-  Optional<QrTicket> findByAttendeeIdAndReservationId(@Param("attendeeId") Long attendeeId,
-      @Param("reservationId") Long reservationId);
+  @Query("SELECT t FROM QrTicket t WHERE t.attendee.id IN :attendeeIds AND t.attendee.reservation.reservationId IN :reservationIds")
+  List<QrTicket> findByAttendeeIdsAndReservationIds(
+      @Param("attendeeIds") Set<Long> attendeeIds,
+      @Param("reservationIds") Set<Long> reservationIds
+  );
 }

--- a/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
@@ -29,4 +29,8 @@ public interface QrTicketRepository extends JpaRepository<QrTicket, Long> {
   Optional<QrTicket> findByAttendee(Attendee attendee);
 
   Optional<QrTicket> findByTicketNo(String ticketNo);
+
+  @Query("select qt from QrTicket qt join qt.attendee a where a.id = :attendeeId and a.reservation.reservationId = :reservationId")
+  Optional<QrTicket> findByAttendeeIdAndReservationId(@Param("attendeeId") Long attendeeId,
+      @Param("reservationId") Long reservationId);
 }

--- a/src/main/java/com/fairing/fairplay/qr/service/QrEntryValidateService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrEntryValidateService.java
@@ -3,13 +3,13 @@ package com.fairing.fairplay.qr.service;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.event.entity.EventDetail;
 import com.fairing.fairplay.qr.dto.EntryPolicyDto;
+import com.fairing.fairplay.qr.entity.QrActionCode;
 import com.fairing.fairplay.qr.entity.QrCheckLog;
 import com.fairing.fairplay.qr.entity.QrCheckStatusCode;
 import com.fairing.fairplay.qr.entity.QrTicket;
 import com.fairing.fairplay.qr.repository.QrActionCodeRepository;
 import com.fairing.fairplay.qr.repository.QrCheckLogRepository;
 import com.fairing.fairplay.qr.repository.QrCheckStatusCodeRepository;
-import com.fairing.fairplay.qr.repository.QrLogRepository;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +22,8 @@ public class QrEntryValidateService {
 
   private final QrCheckLogRepository qrCheckLogRepository;
   private final QrLogService qrLogService;
+  private final QrActionCodeRepository qrActionCodeRepository;
+  private final QrCheckStatusCodeRepository qrCheckStatusCodeRepository;
 
   // 재입장 가능 여부 검토
   public void verifyReEntry(QrTicket qrTicket) {
@@ -66,60 +68,157 @@ public class QrEntryValidateService {
 
   // 잘못된 순서로 스캔 ( checkStatus - 시도하려는 동작 )
   public void preventInvalidScan(QrTicket qrTicket, String checkStatus) {
+    EntryPolicyDto entryPolicy = buildEntryPolicy(qrTicket);
+    QrActionCode qrActionCode = validateQrActionCode(QrActionCode.INVALID);
+    QrCheckStatusCode qrCheckStatusCode = validateQrCheckStatusCode(
+        QrCheckStatusCode.INVALID);
+
     Optional<QrCheckLog> lastLogOpt = qrCheckLogRepository.findTop1ByQrTicketOrderByCreatedAtDesc(
         qrTicket);
 
-    // 처음 입장하여 직전 로그가 없는데 EXIT 스캔하는 경우
+    // 이전 로그가 없는 경우(초기 상태)
     if (lastLogOpt.isEmpty()) {
-      if (QrCheckStatusCode.EXIT.equals(checkStatus)) {
-        qrLogService.invalidQrLog(qrTicket);
-        throw new CustomException(HttpStatus.BAD_REQUEST, "");
+      // EXIT은 불가.단. 퇴장 스캔만하고 입장 스캔을 하지 않는 행사일 경우가 아니어야함.
+      if (QrCheckStatusCode.EXIT.equals(checkStatus) && !(!entryPolicy.getCheckInAllowed()
+          && entryPolicy.getCheckOutAllowed())) {
+        qrLogService.invalidQrLog(qrTicket, qrActionCode, qrCheckStatusCode);
+        throw new CustomException(HttpStatus.BAD_REQUEST, "입장 처리가 완료된 티켓이 아닙니다.");
+      }
+      // 재입장 허용되지 않는 행사인데 재입장 스캔할 경우 예외 발생
+      if (QrCheckStatusCode.REENTRY.equals(checkStatus) && !entryPolicy.getReentryAllowed()) {
+        qrLogService.invalidQrLog(qrTicket, qrActionCode, qrCheckStatusCode);
+        throw new CustomException(HttpStatus.UNAUTHORIZED, "재입장이 허용되지 않는 행사입니다.");
       }
       return;
     }
 
-    boolean isValid = isQrCheckStatusCodeValid(checkStatus, lastLogOpt.get());
-
-    // 만약 isValid가 false로 변경 -> 직전 statuscode가 올바르지 않음
-    if (!isValid) {
-      qrLogService.invalidQrLog(qrTicket);
+    // 상태 전이 + 이벤트 정책(입장,퇴장,재입장 허용)을 같이 검사
+    QrCheckLog qrCheckLog = lastLogOpt.get();
+    if (!isQrCheckStatusCodeValid(checkStatus, qrCheckLog, entryPolicy)) {
+      qrLogService.invalidQrLog(qrTicket, qrActionCode, qrCheckStatusCode);
       throw new CustomException(HttpStatus.BAD_REQUEST,
           "잘못된 입퇴장 동작입니다. 마지막 상태: "
               + lastLogOpt.get().getCheckStatusCode().getName());
     }
   }
 
-  public boolean isQrCheckStatusCodeValid(String checkStatus, QrCheckLog lastLogOpt) {
+  public boolean isQrCheckStatusCodeValid(String checkStatus, QrCheckLog lastLogOpt,
+      EntryPolicyDto entryPolicy) {
     String lastStatus = lastLogOpt.getCheckStatusCode().getCode();
 
-    boolean isValid = true;
-    if (QrCheckStatusCode.ENTRY.equals(checkStatus)) {
-      // ENTRY는 직전이 EXIT 여야 입장 가능
-      isValid = QrCheckStatusCode.EXIT.equals(lastStatus);
-    } else if (QrCheckStatusCode.REENTRY.equals(checkStatus)) {
-      // REENTRY는 직전이 EXIT 여야 입장 가능
-      isValid = QrCheckStatusCode.EXIT.equals(lastStatus);
-    } else if (QrCheckStatusCode.EXIT.equals(checkStatus)) {
-      // EXIT는 직전이 ENTRY, REENTRY 여야 입장 가능
-      isValid = QrCheckStatusCode.ENTRY.equals(lastStatus) || QrCheckStatusCode.REENTRY.equals(
-          lastStatus);
+    boolean reentryAllowed = entryPolicy.getCheckInAllowed();
+    boolean checkInAllowed = entryPolicy.getCheckInAllowed();
+    boolean checkOutAllowed = entryPolicy.getCheckOutAllowed();
+
+    /*
+     * 입장 스캔 퇴장 스캔 재입장가능
+     *
+     * 재입장 가능
+     * 입장, 퇴장
+     * -> 입장스캔 -> 아무기록 없으면 가능
+     * -> 재입장스캔 -> 이전 퇴장 스캔 기록 O 가능(필요하면 입장스캔기록ㄲ자ㅣ..?)
+     * -> 퇴장 스캔 -> 이전 입장 또는 재입장 스캔 있어야 가능
+     * 입장만
+     * -> 입장 스캔 -> 아무 기록 없으면 언제나 가능
+     * -> 재입장 스캔 -> 이전 입장 기록 있어야 가능
+     * 퇴장만
+     * -> 퇴장 스캔 -> 아무기록없거나 퇴장 기록이 있으면 가능. 대신 퇴장 기록 있으면 입장했다고 판단
+     *
+     * 재입장 불가능
+     * 입장, 퇴장
+     * -> 입장스캔 -> 아무기록 없으면 가능
+     * -> 재입장스캔 -> 이전 입장스캔 기록 있으면 안됨
+     * -> 퇴장 스캔 -> 이전 입장스캔 기록 있어야됨. 이전 퇴장 스캔 기록 있으면 안됨
+     * 입장만
+     * -> 입장 스캔 -> 아무 기록 없으면 언제나 가능
+     * -> 재입장 스캔 -> 이전 입장스캔 기록 있으면 안됨
+     * 퇴장만
+     * -> 퇴장 스캔 -> 아무 기록 없으면 가능. 단, 한개의 퇴장기록이라도 있으면 재입장 안됨
+     * */
+    // --- 재입장 허용 ---
+    if (reentryAllowed) {
+      if (checkInAllowed && checkOutAllowed) {
+        // 입·퇴장 모두 스캔
+        if (QrCheckStatusCode.ENTRY.equals(checkStatus)) { // 만약 현재 동작이 입장일 경우
+          return QrCheckStatusCode.EXIT.equals(lastStatus); // 이전 기록이 퇴장이면 가능 true
+        } else if (QrCheckStatusCode.REENTRY.equals(checkStatus)) { //현재 동작 재입장
+          return QrCheckStatusCode.EXIT.equals(lastStatus); // 이전 기록 퇴장이면 가능
+        } else if (QrCheckStatusCode.EXIT.equals(checkStatus)) { // 현재 동작 퇴장
+          return QrCheckStatusCode.ENTRY.equals(lastStatus) // 이전 기록 입장 또는 재입장이면 가능
+              || QrCheckStatusCode.REENTRY.equals(lastStatus);
+        }
+      } else if (checkInAllowed) {
+        // 입장만 스캔
+        if (QrCheckStatusCode.ENTRY.equals(checkStatus)) { // 현재 동작이 입장일 경우
+          return true; // 아무 기록 없어도 가능
+        } else if (QrCheckStatusCode.REENTRY.equals(checkStatus)) { // 현재 동작이 재입장일 경우
+          return QrCheckStatusCode.ENTRY.equals(lastStatus); // 이전 동작이 입장이면 가능
+        }
+      } else if (checkOutAllowed) {
+        // 퇴장만 스캔
+        return QrCheckStatusCode.EXIT.equals(checkStatus); // 현재 동작이 퇴장일 경우
+      }
     }
-    return isValid;
+
+    // --- 재입장 불가 ---
+    else {
+      if (checkInAllowed && checkOutAllowed) {
+        // 입·퇴장 모두 스캔
+        if (QrCheckStatusCode.ENTRY.equals(checkStatus)) { // 현재 동작이 입장일 경우
+          return true; // 첫 입장 가능
+        } else if (QrCheckStatusCode.REENTRY.equals(checkStatus)) { // 현재 동작이 재입장일 경우
+          return false; // 재입장 불가
+        } else if (QrCheckStatusCode.EXIT.equals(checkStatus)) { // 현재 동작이 퇴장일 경우
+          return QrCheckStatusCode.ENTRY.equals(lastStatus); // 이전 동작이 입장이면 가능
+        }
+      } else if (checkInAllowed) {
+        // 입장만 스캔
+        if (QrCheckStatusCode.ENTRY.equals(checkStatus)) { // 현재 동작이 입장일 경우
+          return true; // 첫 입장 가능
+        } else if (QrCheckStatusCode.REENTRY.equals(checkStatus)) { // 현재 동작이 재입장일 경우
+          return false; // 입장 불가
+        }
+      } else if (checkOutAllowed) {
+        // 퇴장만 스캔
+        if (QrCheckStatusCode.EXIT.equals(checkStatus)) { // 현재 동작이 퇴장일 경우
+          return !QrCheckStatusCode.EXIT.equals(lastStatus); // 이전 동작이 없으면 가능. 있으면 재입장임
+        }
+      }
+    }
+
+    return false;
   }
 
   // 중복 스캔 방지 - 최근 기록을 보고 너무 짧은 시간 내의 동일 상태 코드를 막음
   public void preventDuplicateScan(QrTicket qrTicket, String statusCode) {
     Optional<QrCheckLog> lastLogOpt = qrCheckLogRepository.findTop1ByQrTicketAndCheckStatusCode_CodeOrderByCreatedAtDesc(
         qrTicket, statusCode);
+    QrActionCode invalidQrActionCode = validateQrActionCode(
+        QrActionCode.INVALID);
+    QrCheckStatusCode duplicateQrCheckStatusCode = validateQrCheckStatusCode(
+        QrCheckStatusCode.DUPLICATE);
 
     // 5초 간격으로 빠르게 스캔했을 경우
     if (lastLogOpt.isPresent()) {
       QrCheckLog lastLog = lastLogOpt.get();
       if (lastLog.getCreatedAt().isAfter(LocalDateTime.now().minusSeconds(5))) {
-        qrLogService.duplicateQrLog(qrTicket);
+        qrLogService.duplicateQrLog(qrTicket, invalidQrActionCode, duplicateQrCheckStatusCode);
         throw new CustomException(HttpStatus.CONFLICT, "QR 코드를 너무 빠르게 스캔하였습니다.");
       }
     }
+  }
+
+  // QR 로그 코드 검증
+  public QrActionCode validateQrActionCode(String qrActionCode) {
+    return qrActionCodeRepository.findByCode(qrActionCode)
+        .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, "QR 상태 코드가 올바르지 않습니다."));
+  }
+
+  // QR 체크인 코드 검증
+  public QrCheckStatusCode validateQrCheckStatusCode(String qrCheckStatusCode) {
+    return qrCheckStatusCodeRepository.findByCode(qrCheckStatusCode)
+        .orElseThrow(() -> new CustomException(
+            HttpStatus.BAD_REQUEST, "QR 체크인 상태 코드가 올바르지 않습니다."));
   }
 
   private EntryPolicyDto buildEntryPolicy(QrTicket qrTicket) {

--- a/src/main/java/com/fairing/fairplay/qr/service/QrEntryValidateService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrEntryValidateService.java
@@ -1,0 +1,135 @@
+package com.fairing.fairplay.qr.service;
+
+import com.fairing.fairplay.common.exception.CustomException;
+import com.fairing.fairplay.event.entity.EventDetail;
+import com.fairing.fairplay.qr.dto.EntryPolicyDto;
+import com.fairing.fairplay.qr.entity.QrCheckLog;
+import com.fairing.fairplay.qr.entity.QrCheckStatusCode;
+import com.fairing.fairplay.qr.entity.QrTicket;
+import com.fairing.fairplay.qr.repository.QrActionCodeRepository;
+import com.fairing.fairplay.qr.repository.QrCheckLogRepository;
+import com.fairing.fairplay.qr.repository.QrCheckStatusCodeRepository;
+import com.fairing.fairplay.qr.repository.QrLogRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QrEntryValidateService {
+
+  private final QrCheckLogRepository qrCheckLogRepository;
+  private final QrLogService qrLogService;
+
+  // 재입장 가능 여부 검토
+  public void verifyReEntry(QrTicket qrTicket) {
+    EntryPolicyDto entryPolicy = buildEntryPolicy(qrTicket);
+
+    boolean hasEntry = qrLogService.hasCheckRecord(qrTicket, QrCheckStatusCode.ENTRY) != null;
+    boolean hasExit = qrLogService.hasCheckRecord(qrTicket, QrCheckStatusCode.EXIT) != null;
+
+    if (entryPolicy.getReentryAllowed()) {
+      verifyAllowedReEntry(entryPolicy, hasEntry, hasExit);
+    } else {
+      verifyDisallowedReEntry(hasEntry, hasExit);
+    }
+  }
+
+  // 재입장 가능한 행사일 경우 재입장 가능 여부 검토
+  public void verifyAllowedReEntry(EntryPolicyDto entryPolicy, boolean hasEntry, boolean hasExit) {
+    if (entryPolicy.getCheckInAllowed() && entryPolicy.getCheckOutAllowed()) {
+      // 입/퇴장 모두 스캔
+      if (!hasEntry || !hasExit) {
+        throw new CustomException(HttpStatus.UNAUTHORIZED, "입장 및 퇴장 기록이 모두 있어야 재입장 가능합니다.");
+      }
+    } else if (entryPolicy.getCheckInAllowed()) {
+      // 입장만 스캔
+      if (!hasEntry) {
+        throw new CustomException(HttpStatus.UNAUTHORIZED, "입장 기록이 없어 재입장할 수 없습니다.");
+      }
+    } else if (entryPolicy.getCheckOutAllowed()) {
+      // 퇴장만 스캔
+      if (!hasExit) {
+        throw new CustomException(HttpStatus.UNAUTHORIZED, "퇴장 기록이 없어 재입장할 수 없습니다.");
+      }
+    }
+  }
+
+  // 재입장 불가능한 행사일 경우 재입장 가능 여부 검토
+  public void verifyDisallowedReEntry(boolean hasEntry, boolean hasExit) {
+    if (hasEntry || hasExit) {
+      throw new CustomException(HttpStatus.UNAUTHORIZED, "이미 입장 또는 퇴장된 티켓이므로 입장할 수 없습니다.");
+    }
+  }
+
+  // 잘못된 순서로 스캔 ( checkStatus - 시도하려는 동작 )
+  public void preventInvalidScan(QrTicket qrTicket, String checkStatus) {
+    Optional<QrCheckLog> lastLogOpt = qrCheckLogRepository.findTop1ByQrTicketOrderByCreatedAtDesc(
+        qrTicket);
+
+    // 처음 입장하여 직전 로그가 없는데 EXIT 스캔하는 경우
+    if (lastLogOpt.isEmpty()) {
+      if (QrCheckStatusCode.EXIT.equals(checkStatus)) {
+        qrLogService.invalidQrLog(qrTicket);
+        throw new CustomException(HttpStatus.BAD_REQUEST, "");
+      }
+      return;
+    }
+
+    boolean isValid = isQrCheckStatusCodeValid(checkStatus, lastLogOpt.get());
+
+    // 만약 isValid가 false로 변경 -> 직전 statuscode가 올바르지 않음
+    if (!isValid) {
+      qrLogService.invalidQrLog(qrTicket);
+      throw new CustomException(HttpStatus.BAD_REQUEST,
+          "잘못된 입퇴장 동작입니다. 마지막 상태: "
+              + lastLogOpt.get().getCheckStatusCode().getName());
+    }
+  }
+
+  public boolean isQrCheckStatusCodeValid(String checkStatus, QrCheckLog lastLogOpt) {
+    String lastStatus = lastLogOpt.getCheckStatusCode().getCode();
+
+    boolean isValid = true;
+    if (QrCheckStatusCode.ENTRY.equals(checkStatus)) {
+      // ENTRY는 직전이 EXIT 여야 입장 가능
+      isValid = QrCheckStatusCode.EXIT.equals(lastStatus);
+    } else if (QrCheckStatusCode.REENTRY.equals(checkStatus)) {
+      // REENTRY는 직전이 EXIT 여야 입장 가능
+      isValid = QrCheckStatusCode.EXIT.equals(lastStatus);
+    } else if (QrCheckStatusCode.EXIT.equals(checkStatus)) {
+      // EXIT는 직전이 ENTRY, REENTRY 여야 입장 가능
+      isValid = QrCheckStatusCode.ENTRY.equals(lastStatus) || QrCheckStatusCode.REENTRY.equals(
+          lastStatus);
+    }
+    return isValid;
+  }
+
+  // 중복 스캔 방지 - 최근 기록을 보고 너무 짧은 시간 내의 동일 상태 코드를 막음
+  public void preventDuplicateScan(QrTicket qrTicket, String statusCode) {
+    Optional<QrCheckLog> lastLogOpt = qrCheckLogRepository.findTop1ByQrTicketAndCheckStatusCode_CodeOrderByCreatedAtDesc(
+        qrTicket, statusCode);
+
+    // 5초 간격으로 빠르게 스캔했을 경우
+    if (lastLogOpt.isPresent()) {
+      QrCheckLog lastLog = lastLogOpt.get();
+      if (lastLog.getCreatedAt().isAfter(LocalDateTime.now().minusSeconds(5))) {
+        qrLogService.duplicateQrLog(qrTicket);
+        throw new CustomException(HttpStatus.CONFLICT, "QR 코드를 너무 빠르게 스캔하였습니다.");
+      }
+    }
+  }
+
+  private EntryPolicyDto buildEntryPolicy(QrTicket qrTicket) {
+    EventDetail eventDetail = qrTicket.getEventSchedule().getEvent().getEventDetail();
+
+    // 입장 스캔 여부, 퇴장 스캔 여부, 재입장 가능 여부 정책 dto
+    return EntryPolicyDto.builder()
+        .checkInAllowed(true)
+        .checkOutAllowed(eventDetail.getCheckOutAllowed())
+        .reentryAllowed(eventDetail.getReentryAllowed())
+        .build();
+  }
+}

--- a/src/main/java/com/fairing/fairplay/qr/service/QrLogService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrLogService.java
@@ -11,6 +11,7 @@ import com.fairing.fairplay.qr.repository.QrLogRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,26 +19,27 @@ import org.springframework.transaction.annotation.Transactional;
 // QR과 관련된 로그 서비스
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class QrLogService {
 
   private final QrLogRepository qrLogRepository;
   private final QrCheckLogRepository qrCheckLogRepository;
 
   // QR 코드 발급
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @Transactional
   public void issuedQrLog(List<QrTicket> qrTickets, QrActionCode qrActionCode) {
     saveQrLog(qrTickets, qrActionCode);
   }
 
   // QR 코드 스캔
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @Transactional
   public void scannedQrLog(QrTicket qrTicket, QrActionCode qrActionCode) {
     // 중복 스캔 아닐 경우 ENTRY 스캔을 위해 QrLog: scanned만 저장
     saveQrLog(qrTicket, qrActionCode);
   }
 
   // 입장 (QR 코드 스캔+수동 코드)
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @Transactional
   public LocalDateTime entryQrLog(QrTicket qrTicket, QrActionCode qrActionCode,
       QrCheckStatusCode qrCheckStatusCode) {
     // qrLog: CHECKED_IN or MANUAL_CHECKED_IN 저장
@@ -48,7 +50,7 @@ public class QrLogService {
   }
 
   // 퇴장 (QR 코드 스캔 or 수동 코드)
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @Transactional
   public void exitQrLog(QrTicket qrTicket, QrActionCode qrActionCode,
       QrCheckStatusCode qrCheckStatusCode) {
 //    // checkStatusCode = EXIT
@@ -116,6 +118,7 @@ public class QrLogService {
     for (int i = 0; i < qrTickets.size(); i += BATCH_SIZE) {
       int end = Math.min(i + BATCH_SIZE, qrTickets.size());
       List<QrTicket> batch = qrTickets.subList(i, end);
+      log.info("🚩 List<QrTicket> batch: {}", batch.size());
 
       List<QrLog> logs = batch.stream()
           .map(ticket -> QrLog.builder()
@@ -124,7 +127,7 @@ public class QrLogService {
               .createdAt(LocalDateTime.now())
               .build())
           .toList();
-
+      log.info("🚩 logs: {}", logs.size());
       qrLogRepository.saveAll(logs);
       qrLogRepository.flush(); // 중간 flush로 메모리 사용량 줄임
     }

--- a/src/main/java/com/fairing/fairplay/qr/service/QrLogService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrLogService.java
@@ -1,37 +1,19 @@
 package com.fairing.fairplay.qr.service;
 
-import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.qr.entity.QrActionCode;
 import com.fairing.fairplay.qr.entity.QrCheckLog;
 import com.fairing.fairplay.qr.entity.QrCheckStatusCode;
 import com.fairing.fairplay.qr.entity.QrLog;
 import com.fairing.fairplay.qr.entity.QrTicket;
-import com.fairing.fairplay.qr.repository.QrActionCodeRepository;
 import com.fairing.fairplay.qr.repository.QrCheckLogRepository;
-import com.fairing.fairplay.qr.repository.QrCheckStatusCodeRepository;
+
 import com.fairing.fairplay.qr.repository.QrLogRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-/*
-* 서비스	책임
-QrTicketEntryService	입장/퇴장 요청 처리의 “흐름 제어”
-- 유저/참석자/티켓 조회
-- 권한 검증
-- 중복 스캔·재입장 정책 적용
-- 검증 통과 후 LogService 호출
-QrLogService	로그 데이터 생성/저장/조회
-- DB 접근 전 code 유효성 검증
-- 상태 전이 가능 여부 확인 (마지막 로그 조회)
-- 중복 기록 방지(시간 제한)
-- 로그 생성 시 필요한 엔티티 생성·저장
-* */
-
 
 // QR과 관련된 로그 서비스
 @Service
@@ -40,38 +22,24 @@ public class QrLogService {
 
   private final QrLogRepository qrLogRepository;
   private final QrCheckLogRepository qrCheckLogRepository;
-  private final QrActionCodeRepository qrActionCodeRepository;
-  private final QrCheckStatusCodeRepository qrCheckStatusCodeRepository;
-  private final QrEntryValidateService qrEntryValidateService;
 
   // QR 코드 발급
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void issuedQrLog(List<QrTicket> qrTickets) {
-    QrActionCode qrActionCode = validateQrActionCode(QrActionCode.ISSUED);
+  public void issuedQrLog(List<QrTicket> qrTickets, QrActionCode qrActionCode) {
     saveQrLog(qrTickets, qrActionCode);
   }
 
   // QR 코드 스캔
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void scannedQrLog(QrTicket qrTicket, String checkStatus) {
-    QrActionCode qrActionCode = validateQrActionCode(checkStatus);
-    // 중복 스캔 -> QrLog: invalid, QrChecktLog: duplicate 저장
-    qrEntryValidateService.preventDuplicateScan(qrTicket, checkStatus);
+  public void scannedQrLog(QrTicket qrTicket, QrActionCode qrActionCode) {
     // 중복 스캔 아닐 경우 ENTRY 스캔을 위해 QrLog: scanned만 저장
     saveQrLog(qrTicket, qrActionCode);
   }
 
   // 입장 (QR 코드 스캔+수동 코드)
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public LocalDateTime entryQrLog(QrTicket qrTicket, String actionCodeType,
-      String checkStatusCode) {
-    // actionCodeType = CHECKED_IN, MANUAL_CHECKED_IN
-    QrActionCode qrActionCode = validateQrActionCode(actionCodeType);
-    // checkStatusCode = ENTRY, REENTRY
-    QrCheckStatusCode qrCheckStatusCode = validateQrCheckStatusCode(
-        checkStatusCode);
-    // 잘못된 입퇴장 스캔 -> ENTRY, REENTRY
-    qrEntryValidateService.preventInvalidScan(qrTicket, checkStatusCode);
+  public LocalDateTime entryQrLog(QrTicket qrTicket, QrActionCode qrActionCode,
+      QrCheckStatusCode qrCheckStatusCode) {
     // qrLog: CHECKED_IN or MANUAL_CHECKED_IN 저장
     LocalDateTime entryTime = saveQrLog(qrTicket, qrActionCode);
     // qrCheckLog: ENTRY or REENTRY 저장
@@ -81,33 +49,27 @@ public class QrLogService {
 
   // 퇴장 (QR 코드 스캔 or 수동 코드)
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void exitQrLog(QrTicket qrTicket) {
-    // checkStatusCode = EXIT
-    QrCheckStatusCode qrCheckStatusCode = validateQrCheckStatusCode(
-        QrCheckStatusCode.EXIT);
-    // 잘못된 입퇴장 스캔
-    qrEntryValidateService.preventInvalidScan(qrTicket, QrCheckStatusCode.EXIT);
+  public void exitQrLog(QrTicket qrTicket, QrActionCode qrActionCode,
+      QrCheckStatusCode qrCheckStatusCode) {
+//    // checkStatusCode = EXIT
+//    QrCheckStatusCode qrCheckStatusCode = qrEntryValidateService.validateQrCheckStatusCode(
+//        QrCheckStatusCode.EXIT);
+//    // 잘못된 입퇴장 스캔
+//    qrEntryValidateService.preventInvalidScan(qrTicket, QrCheckStatusCode.EXIT);
     // qrCheckLog: EXIT 저장
     saveQrCheckLog(qrTicket, qrCheckStatusCode);
   }
 
   // 비정상 중복 스캔 -> 스캔할 때 검토
-  public void duplicateQrLog(QrTicket qrTicket) {
-    QrActionCode invalidQrActionCode = validateQrActionCode(
-        QrActionCode.INVALID);
-    QrCheckStatusCode duplicateQrCheckStatusCode = validateQrCheckStatusCode(
-        QrCheckStatusCode.DUPLICATE);
-
-    saveQrLog(qrTicket, invalidQrActionCode);
-    saveQrCheckLog(qrTicket, duplicateQrCheckStatusCode);
+  public void duplicateQrLog(QrTicket qrTicket, QrActionCode qrActionCode,
+      QrCheckStatusCode qrCheckStatusCode) {
+    saveQrLog(qrTicket, qrActionCode);
+    saveQrCheckLog(qrTicket, qrCheckStatusCode);
   }
 
   // 잘못된 스캔 -> 입장, 퇴장 시 검토
-  public void invalidQrLog(QrTicket qrTicket) {
-    QrActionCode qrActionCode = validateQrActionCode(QrActionCode.INVALID);
-    QrCheckStatusCode qrCheckStatusCode = validateQrCheckStatusCode(
-        QrCheckStatusCode.INVALID);
-
+  public void invalidQrLog(QrTicket qrTicket, QrActionCode qrActionCode,
+      QrCheckStatusCode qrCheckStatusCode) {
     saveQrLog(qrTicket, qrActionCode);
     saveQrCheckLog(qrTicket, qrCheckStatusCode);
   }
@@ -135,19 +97,6 @@ public class QrLogService {
       // 직전 로그가 하나라도 있으면 재입장 판단
       return QrCheckStatusCode.REENTRY;
     }
-  }
-
-  // QR 로그 코드 검증
-  private QrActionCode validateQrActionCode(String qrActionCode) {
-    return qrActionCodeRepository.findByCode(qrActionCode)
-        .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, "QR 상태 코드가 올바르지 않습니다."));
-  }
-
-  // QR 체크인 코드 검증
-  private QrCheckStatusCode validateQrCheckStatusCode(String qrCheckStatusCode) {
-    return qrCheckStatusCodeRepository.findByCode(qrCheckStatusCode)
-        .orElseThrow(() -> new CustomException(
-            HttpStatus.BAD_REQUEST, "QR 체크인 상태 코드가 올바르지 않습니다."));
   }
 
   // QrLog 저장 - ISSUED, SCAN, CHECKED_IN, MANUAL_CHECKED_IN, INVALID

--- a/src/main/java/com/fairing/fairplay/qr/service/QrLogService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrLogService.java
@@ -32,7 +32,7 @@ public class QrLogService {
   }
 
   // QR 코드 스캔
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void scannedQrLog(QrTicket qrTicket, QrActionCode qrActionCode) {
     // 중복 스캔 아닐 경우 ENTRY 스캔을 위해 QrLog: scanned만 저장
     saveQrLog(qrTicket, qrActionCode);

--- a/src/main/java/com/fairing/fairplay/qr/service/QrLogService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrLogService.java
@@ -83,6 +83,14 @@ public class QrLogService {
     saveQrCheckLog(qrTicket, qrCheckStatusCode);
   }
 
+  public boolean hasCheckRecord(QrTicket qrTicket, String qrCheckStatus) {
+    return qrCheckLogRepository.findTop1ByQrTicketAndCheckStatusCode_CodeOrderByCreatedAtDesc(qrTicket, qrCheckStatus).isPresent();
+  }
+
+  public boolean hasQrRecord(QrTicket qrTicket, String qrActionCode) {
+    return qrLogRepository.findTop1ByQrTicketAndActionCode_CodeOrderByCreatedAtDesc(qrTicket, qrActionCode).isPresent();
+  }
+
   // 비정상 중복 스캔
   public void duplicateQrLog(QrTicket qrTicket) {
     QrActionCode invalidQrActionCode = validateQrActionCode(QrActionCode.INVALID);

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
@@ -14,11 +14,12 @@ import com.fairing.fairplay.reservation.entity.QReservation;
 import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.reservation.repository.ReservationRepositoryCustom;
 import com.fairing.fairplay.ticket.entity.EventSchedule;
-import com.fairing.fairplay.ticket.service.ScheduleTicketService;
+
 import com.querydsl.core.Tuple;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -87,8 +88,15 @@ public class QrTicketBatchService {
     qrTicketRepository.saveAll(qrTickets);
     qrTicketRepository.flush();
 
+    List<Long> ticketIds = qrTickets.stream()
+        .map(QrTicket::getId)
+        .collect(Collectors.toList());
+
+    List<QrTicket> persistedTickets = qrTicketRepository.findAllById(ticketIds);
+    log.info("🚩 persistedTickets 생성됨: {}", persistedTickets.size());
     QrActionCode qrActionCode = qrEntryValidateService.validateQrActionCode(QrActionCode.ISSUED);
-    qrLogService.issuedQrLog(qrTickets, qrActionCode);
+    log.info("🚩 qrActionCode: {}", qrActionCode.getCode());
+    qrLogService.issuedQrLog(persistedTickets, qrActionCode);
   }
 
   /*

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
@@ -36,7 +36,6 @@ public class QrTicketBatchService {
   private final QrLinkService qrLinkService;
   private final QrTicketRepositoryCustom qrTicketRepositoryCustom;
   private final CodeGenerator codeGenerator;
-  private final ScheduleTicketService scheduleTicketService;
 
   // 행사 1일 남은 예약건 조회
   public List<Tuple> fetchQrTicketBatch() {

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketBatchService.java
@@ -5,6 +5,7 @@ import com.fairing.fairplay.attendee.entity.QAttendee;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.event.entity.Event;
 import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
+import com.fairing.fairplay.qr.entity.QrActionCode;
 import com.fairing.fairplay.qr.entity.QrTicket;
 import com.fairing.fairplay.qr.repository.QrTicketRepository;
 import com.fairing.fairplay.qr.repository.QrTicketRepositoryCustom;
@@ -37,6 +38,7 @@ public class QrTicketBatchService {
   private final QrTicketRepositoryCustom qrTicketRepositoryCustom;
   private final CodeGenerator codeGenerator;
   private final QrLogService qrLogService;
+  private final QrEntryValidateService qrEntryValidateService;
 
   // 행사 1일 남은 예약건 조회
   public List<Tuple> fetchQrTicketBatch() {
@@ -85,7 +87,8 @@ public class QrTicketBatchService {
     qrTicketRepository.saveAll(qrTickets);
     qrTicketRepository.flush();
 
-    qrLogService.issuedQrLog(qrTickets);
+    QrActionCode qrActionCode = qrEntryValidateService.validateQrActionCode(QrActionCode.ISSUED);
+    qrLogService.issuedQrLog(qrTickets, qrActionCode);
   }
 
   /*
@@ -106,7 +109,8 @@ public class QrTicketBatchService {
           Reservation r = tuple.get(2, Reservation.class);
 
           // true면 이미 발급됐으니 필터링에서 제외
-          return !qrTicketRepository.findByAttendeeIdAndReservationId(a.getId(), r.getReservationId()).isPresent();
+          return !qrTicketRepository.findByAttendeeIdAndReservationId(a.getId(),
+              r.getReservationId()).isPresent();
         })
         .map(tuple -> {
           Attendee a = tuple.get(0, Attendee.class);

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketEntryService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketEntryService.java
@@ -5,13 +5,16 @@ import com.fairing.fairplay.attendee.entity.AttendeeTypeCode;
 import com.fairing.fairplay.attendee.repository.AttendeeRepository;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.event.entity.EventDetail;
 import com.fairing.fairplay.qr.dto.CheckInResponseDto;
+import com.fairing.fairplay.qr.dto.EntryPolicyDto;
 import com.fairing.fairplay.qr.dto.GuestManualCheckInRequestDto;
 import com.fairing.fairplay.qr.dto.GuestQrCheckInRequestDto;
 import com.fairing.fairplay.qr.dto.MemberManualCheckInRequestDto;
 import com.fairing.fairplay.qr.dto.MemberQrCheckInRequestDto;
 import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
 import com.fairing.fairplay.qr.entity.QrCheckLog;
+import com.fairing.fairplay.qr.entity.QrCheckStatusCode;
 import com.fairing.fairplay.qr.entity.QrLog;
 import com.fairing.fairplay.qr.entity.QrTicket;
 import com.fairing.fairplay.qr.repository.QrCheckLogRepository;
@@ -24,10 +27,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-// QR 티켓 입장/퇴장
+//QrTicketEntryService	입장/퇴장 요청 처리의 “흐름 제어”
+//    - 유저/참석자/티켓 조회
+//- 권한 검증
+//- 중복 스캔·재입장 정책 적용
+//- 검증 통과 후 LogService 호출
 @Service
 @RequiredArgsConstructor
 public class QrTicketEntryService {
+
   private final QrTicketRepository qrTicketRepository;
   private final AttendeeRepository attendeeRepository;
   private final CodeValidator codeValidator; // 검증 로직 분리
@@ -40,15 +48,15 @@ public class QrTicketEntryService {
     // 예약자 조회
     Attendee attendee = findAttendeeByReservation(dto.getReservationId());
     // 예약자와 현재 로그인한 사용자 일치 여부 조회
-    if(!userDetails.getUserId().equals(attendee.getReservation().getUser().getUserId()))  {
-      throw new CustomException(HttpStatus.UNAUTHORIZED,"예약자와 현재 로그인한 사용자가 일치하지 않습니다.");
+    if (!userDetails.getUserId().equals(attendee.getReservation().getUser().getUserId())) {
+      throw new CustomException(HttpStatus.UNAUTHORIZED, "예약자와 현재 로그인한 사용자가 일치하지 않습니다.");
     }
     // QR 티켓 조회
     QrTicket qrTicket = findQrTicket(attendee);
-    // qrcode 비교
-    verifyQrCode(qrTicket, dto.getQrCode());
     // 재입장 여부 검토
     verifyReEntry(qrTicket);
+    // qrcode 비교
+    verifyQrCode(qrTicket, dto.getQrCode());
     // QR 티켓 처리
     LocalDateTime checkInTime = processCheckIn(qrTicket);
 
@@ -59,19 +67,20 @@ public class QrTicketEntryService {
   }
 
   // 회원 수동 코드 체크인
-  public CheckInResponseDto checkIn(MemberManualCheckInRequestDto dto, CustomUserDetails userDetails) {
+  public CheckInResponseDto checkIn(MemberManualCheckInRequestDto dto,
+      CustomUserDetails userDetails) {
     // 예약자 조회
     Attendee attendee = findAttendeeByReservation(dto.getReservationId());
     // 예약자와 현재 로그인한 사용자 일치 여부 조회
-    if(!userDetails.getUserId().equals(attendee.getReservation().getUser().getUserId()))  {
-      throw new CustomException(HttpStatus.UNAUTHORIZED,"예약자와 현재 로그인한 사용자가 일치하지 않습니다.");
+    if (!userDetails.getUserId().equals(attendee.getReservation().getUser().getUserId())) {
+      throw new CustomException(HttpStatus.UNAUTHORIZED, "예약자와 현재 로그인한 사용자가 일치하지 않습니다.");
     }
     // QR 티켓 조회
     QrTicket qrTicket = findQrTicket(attendee);
-    // 수동 코드 비교
-    verifyManualCode(qrTicket, dto.getManualCode());
     // 재입장 여부 검토
     verifyReEntry(qrTicket);
+    // 수동 코드 비교
+    verifyManualCode(qrTicket, dto.getManualCode());
     // QR 티켓 처리
     LocalDateTime checkInTime = processCheckIn(qrTicket);
     return CheckInResponseDto.builder()
@@ -88,10 +97,10 @@ public class QrTicketEntryService {
     Attendee attendee = findAttendeeByAttendee(qrLinkTokenInfo.getAttendeeId());
     // qr 티켓 조회
     QrTicket qrTicket = findQrTicket(attendee);
-    // qrcode 비교
-    verifyQrCode(qrTicket, dto.getQrCode());
     // 재입장 여부 검토
     verifyReEntry(qrTicket);
+    // qrcode 비교
+    verifyQrCode(qrTicket, dto.getQrCode());
     // QR 티켓 처리
     LocalDateTime checkInTime = processCheckIn(qrTicket);
     return CheckInResponseDto.builder()
@@ -108,10 +117,10 @@ public class QrTicketEntryService {
     Attendee attendee = findAttendeeByAttendee(qrLinkTokenInfo.getAttendeeId());
     // qr 티켓 조회
     QrTicket qrTicket = findQrTicket(attendee);
-    // 수동 코드 비교
-    verifyManualCode(qrTicket, dto.getManualCode());
     // 재입장 여부 검토
     verifyReEntry(qrTicket);
+    // 수동 코드 비교
+    verifyManualCode(qrTicket, dto.getManualCode());
     // QR 티켓 처리
     LocalDateTime checkInTime = processCheckIn(qrTicket);
     return CheckInResponseDto.builder()
@@ -145,13 +154,6 @@ public class QrTicketEntryService {
       throw new CustomException(HttpStatus.BAD_REQUEST, "만료된 QR 티켓입니다.");
     }
 
-    QrLog qrLog = qrLogRepository.findByActionCode_Code("").orElse(null);
-
-    // 재입장 여부 확인
-    if (qrLog != null && !qrTicket.getReentryAllowed()) {
-      throw new CustomException(HttpStatus.UNAUTHORIZED, "이미 입장한 이력이 있으며 재입장할 수 없습니다.");
-    }
-
     if (!qrTicket.getQrCode().equals(qrCode)) {
       throw new CustomException(HttpStatus.UNAUTHORIZED, "참석자 정보와 일치하지 않습니다.");
     }
@@ -168,32 +170,50 @@ public class QrTicketEntryService {
 
   // 재입장 가능 여부 검토
   private void verifyReEntry(QrTicket qrTicket) {
-    // 체크인/체크아웃 로그 조회 (해당 티켓, 사용자 기준)
-    Optional<QrCheckLog> qrLogCheckInOpt = qrCheckLogRepository.findTop1ByQrTicketAndCheckStatusCode_CodeOrderByCreatedAtDesc(
-        qrTicket, "CHECKIN");
-    Optional<QrCheckLog> qrLogCheckOutOpt = qrCheckLogRepository.findTop1ByQrTicketAndCheckStatusCode_CodeOrderByCreatedAtDesc(
-        qrTicket, "CHECKOUT");
+    // 입장 스캔 여부, 퇴장 스캔 여부, 재입장 가능 여부 정책 dto
+    EntryPolicyDto entryPolicyDto = buildEntryPolicy(qrTicket);
 
-    // 체크아웃
-    boolean checkOutAllowed = qrTicket.getEventSchedule().getEvent().getEventDetail()
-        .getCheckOutAllowed();
-
-    boolean hasCheckIn = qrLogCheckInOpt.isPresent();
-    boolean hasCheckOut = qrLogCheckOutOpt.isPresent();
-
-    // 재입장 불가 + 입장 기록 있음
-    if (!qrTicket.getReentryAllowed() && hasCheckIn) {
-      throw new CustomException(HttpStatus.UNAUTHORIZED, "입장한 기록이 있으므로 재입장할 수 없습니다.");
+    if (entryPolicyDto.getReentryAllowed()) {
+      canReEntry(qrTicket, entryPolicyDto);
+    } else {
+      cantReEntry(qrTicket, entryPolicyDto);
     }
+  }
 
-    // 재입장 불가 + 퇴장 기록 없음(퇴장 가능 이벤트에서)
-    if (!qrTicket.getReentryAllowed() && checkOutAllowed && !hasCheckOut) {
-      throw new CustomException(HttpStatus.UNAUTHORIZED, "퇴장한 기록이 없으므로 재입장할 수 없습니다.");
+  private void canReEntry(QrTicket qrTicket, EntryPolicyDto entryPolicyDto) {
+    boolean hasEntry = qrLogService.hasCheckRecord(qrTicket, QrCheckStatusCode.ENTRY);
+    boolean hasExit = qrLogService.hasCheckRecord(qrTicket, QrCheckStatusCode.EXIT);
+    boolean hasReEntry = qrLogService.hasCheckRecord(qrTicket, QrCheckStatusCode.REENTRY);
+
+    // 입장스캔O 퇴장스캔0 입장기록있음
+    if (entryPolicyDto.getCheckInAllowed() && entryPolicyDto.getCheckOutAllowed()
+        && hasEntry && !hasExit) {
+      throw new CustomException(HttpStatus.UNAUTHORIZED, "퇴장 처리가 되지 않아 재입장하실 수 없습니다.");
+    } else if (!entryPolicyDto.getCheckInAllowed() && entryPolicyDto.getCheckOutAllowed()
+        && !hasExit) {
+      // 입장스캔X 퇴장스캔0 퇴장 기록 없음
+      throw new CustomException(HttpStatus.UNAUTHORIZED, "퇴장 처리가 되지 않아 재입장하실 수 없습니다.");
+    } else if (entryPolicyDto.getCheckInAllowed() && !entryPolicyDto.getCheckOutAllowed()
+        && !(hasEntry || hasReEntry)) {
+      // 입장스캔O 퇴장스캔X 입장 기록 없음
+      throw new CustomException(HttpStatus.UNAUTHORIZED, "입장 처리가 되지 않아 재입장하실 수 없습니다.");
+    }
+  }
+
+  private void cantReEntry(QrTicket qrTicket, EntryPolicyDto entryPolicyDto) {
+    boolean hasEntry = qrLogService.hasCheckRecord(qrTicket, QrCheckStatusCode.ENTRY);
+    boolean hasExit = qrLogService.hasCheckRecord(qrTicket, QrCheckStatusCode.EXIT);
+
+    // 입장스캔O 퇴장스캔0 입장기록있음
+    if ((entryPolicyDto.getCheckInAllowed() && entryPolicyDto.getCheckOutAllowed() && hasEntry)
+        || (!entryPolicyDto.getCheckInAllowed() && entryPolicyDto.getCheckOutAllowed() && hasExit)
+        || (entryPolicyDto.getCheckInAllowed() && !entryPolicyDto.getCheckOutAllowed() && hasEntry)) {
+      throw new CustomException(HttpStatus.UNAUTHORIZED, "이미 입장 또는 퇴장 완료된 티켓이므로 재입장하실 수 없습니다.");
     }
   }
 
   // 검증 완료 후 디비 데이터 저장
-  private LocalDateTime processCheckIn(QrTicket ticket ) {
+  private LocalDateTime processCheckIn(QrTicket ticket) {
     // qr코드 상태변경 log
     qrLogSave(ticket, "CHECKIN");
     // 체크인 상태변경 log
@@ -203,7 +223,18 @@ public class QrTicketEntryService {
   }
 
   // QR 로그 저장
-  private void qrLogSave(QrTicket qrTicket, String type){
+  private void qrLogSave(QrTicket qrTicket, String type) {
 //    qrLogService(qrTicket, type);
+  }
+
+  private EntryPolicyDto buildEntryPolicy(QrTicket qrTicket) {
+    EventDetail eventDetail = qrTicket.getEventSchedule().getEvent().getEventDetail();
+
+    // 입장 스캔 여부, 퇴장 스캔 여부, 재입장 가능 여부 정책 dto
+    return EntryPolicyDto.builder()
+        .checkInAllowed(true)
+        .checkOutAllowed(eventDetail.getCheckOutAllowed())
+        .reentryAllowed(eventDetail.getReentryAllowed())
+        .build();
   }
 }

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketEntryService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketEntryService.java
@@ -5,33 +5,23 @@ import com.fairing.fairplay.attendee.entity.AttendeeTypeCode;
 import com.fairing.fairplay.attendee.repository.AttendeeRepository;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.security.CustomUserDetails;
-import com.fairing.fairplay.event.entity.EventDetail;
 import com.fairing.fairplay.qr.dto.CheckInResponseDto;
-import com.fairing.fairplay.qr.dto.EntryPolicyDto;
 import com.fairing.fairplay.qr.dto.GuestManualCheckInRequestDto;
 import com.fairing.fairplay.qr.dto.GuestQrCheckInRequestDto;
 import com.fairing.fairplay.qr.dto.MemberManualCheckInRequestDto;
 import com.fairing.fairplay.qr.dto.MemberQrCheckInRequestDto;
 import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
-import com.fairing.fairplay.qr.entity.QrCheckLog;
+import com.fairing.fairplay.qr.entity.QrActionCode;
 import com.fairing.fairplay.qr.entity.QrCheckStatusCode;
-import com.fairing.fairplay.qr.entity.QrLog;
 import com.fairing.fairplay.qr.entity.QrTicket;
-import com.fairing.fairplay.qr.repository.QrCheckLogRepository;
-import com.fairing.fairplay.qr.repository.QrLogRepository;
 import com.fairing.fairplay.qr.repository.QrTicketRepository;
 import com.fairing.fairplay.qr.util.CodeValidator;
 import java.time.LocalDateTime;
-import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-//QrTicketEntryService	입장/퇴장 요청 처리의 “흐름 제어”
-//    - 유저/참석자/티켓 조회
-//- 권한 검증
-//- 중복 스캔·재입장 정책 적용
-//- 검증 통과 후 LogService 호출
 @Service
 @RequiredArgsConstructor
 public class QrTicketEntryService {
@@ -39,9 +29,8 @@ public class QrTicketEntryService {
   private final QrTicketRepository qrTicketRepository;
   private final AttendeeRepository attendeeRepository;
   private final CodeValidator codeValidator; // 검증 로직 분리
-  private final QrLogRepository qrLogRepository;
-  private final QrCheckLogRepository qrCheckLogRepository;
   private final QrLogService qrLogService;
+  private final QrEntryValidateService qrEntryValidateService;
 
   // 회원 QR 코드 체크인
   public CheckInResponseDto checkIn(MemberQrCheckInRequestDto dto, CustomUserDetails userDetails) {
@@ -53,12 +42,26 @@ public class QrTicketEntryService {
     }
     // QR 티켓 조회
     QrTicket qrTicket = findQrTicket(attendee);
-    // 재입장 여부 검토
-    verifyReEntry(qrTicket);
+    // 코드 스캔 기록
+    qrLogService.scannedQrLog(qrTicket, QrActionCode.SCANNED);
+    /*
+    * 1. 재입장 가능 여부 검토 => qrEntryPolicyService
+    * 2. 최초 입장인지 재입장인지 판단 => qrLogService
+    * 3. 코드 스캔 로그 기록 => qrLogService
+    * 4. QR 코드 일치 하는 지 검토 => qrTicketEntryService
+    * 5. QR 티켓 처리 => qrTicketEntryService
+    * - 중복 스캔 여부 검토 -> 로그 기록 후 예외 => qrLogService
+    * - 잘못된 스캔 여부 검토 -> 로그 기록 후 예외 => qrLogService
+    * - QR 체크인 로그 기록 => qrLogService
+    * */
+    // 재입장 가능 여부 검토 - 입장 기록 자체가 있는지 조회
+    qrEntryValidateService.verifyReEntry(qrTicket);
+    // 현재 입장이 최초입장인지 재입장인지 판단 QrCheckStatusCode.ENTRY, rCheckStatusCode.REENTRY
+    String entryType = qrLogService.determineEntryOrReEntry(qrTicket);
     // qrcode 비교
     verifyQrCode(qrTicket, dto.getQrCode());
     // QR 티켓 처리
-    LocalDateTime checkInTime = processCheckIn(qrTicket);
+    LocalDateTime checkInTime = processCheckIn(qrTicket, QrActionCode.CHECKED_IN, entryType);
 
     return CheckInResponseDto.builder()
         .message("체크인 완료되었습니다.")
@@ -78,11 +81,12 @@ public class QrTicketEntryService {
     // QR 티켓 조회
     QrTicket qrTicket = findQrTicket(attendee);
     // 재입장 여부 검토
-    verifyReEntry(qrTicket);
+
     // 수동 코드 비교
     verifyManualCode(qrTicket, dto.getManualCode());
     // QR 티켓 처리
-    LocalDateTime checkInTime = processCheckIn(qrTicket);
+    LocalDateTime checkInTime = processCheckIn(qrTicket, QrActionCode.MANUAL_CHECKED_IN,
+        true ? QrCheckStatusCode.REENTRY : QrCheckStatusCode.ENTRY);
     return CheckInResponseDto.builder()
         .message("체크인 완료되었습니다.")
         .checkInTime(checkInTime)
@@ -97,12 +101,15 @@ public class QrTicketEntryService {
     Attendee attendee = findAttendeeByAttendee(qrLinkTokenInfo.getAttendeeId());
     // qr 티켓 조회
     QrTicket qrTicket = findQrTicket(attendee);
+    // 코드 스캔 기록
+    qrLogService.scannedQrLog(qrTicket, QrActionCode.SCANNED);
     // 재입장 여부 검토
-    verifyReEntry(qrTicket);
+
     // qrcode 비교
     verifyQrCode(qrTicket, dto.getQrCode());
     // QR 티켓 처리
-    LocalDateTime checkInTime = processCheckIn(qrTicket);
+    LocalDateTime checkInTime = processCheckIn(qrTicket, QrActionCode.CHECKED_IN,
+        true ? QrCheckStatusCode.REENTRY : QrCheckStatusCode.ENTRY);
     return CheckInResponseDto.builder()
         .message("체크인 완료되었습니다.")
         .checkInTime(checkInTime)
@@ -118,11 +125,12 @@ public class QrTicketEntryService {
     // qr 티켓 조회
     QrTicket qrTicket = findQrTicket(attendee);
     // 재입장 여부 검토
-    verifyReEntry(qrTicket);
+
     // 수동 코드 비교
     verifyManualCode(qrTicket, dto.getManualCode());
     // QR 티켓 처리
-    LocalDateTime checkInTime = processCheckIn(qrTicket);
+    LocalDateTime checkInTime = processCheckIn(qrTicket, QrActionCode.MANUAL_CHECKED_IN,
+        true ? QrCheckStatusCode.REENTRY : QrCheckStatusCode.ENTRY);
     return CheckInResponseDto.builder()
         .message("체크인 완료되었습니다.")
         .checkInTime(checkInTime)
@@ -168,73 +176,8 @@ public class QrTicketEntryService {
     }
   }
 
-  // 재입장 가능 여부 검토
-  private void verifyReEntry(QrTicket qrTicket) {
-    // 입장 스캔 여부, 퇴장 스캔 여부, 재입장 가능 여부 정책 dto
-    EntryPolicyDto entryPolicyDto = buildEntryPolicy(qrTicket);
-
-    if (entryPolicyDto.getReentryAllowed()) {
-      canReEntry(qrTicket, entryPolicyDto);
-    } else {
-      cantReEntry(qrTicket, entryPolicyDto);
-    }
-  }
-
-  private void canReEntry(QrTicket qrTicket, EntryPolicyDto entryPolicyDto) {
-    boolean hasEntry = qrLogService.hasCheckRecord(qrTicket, QrCheckStatusCode.ENTRY);
-    boolean hasExit = qrLogService.hasCheckRecord(qrTicket, QrCheckStatusCode.EXIT);
-    boolean hasReEntry = qrLogService.hasCheckRecord(qrTicket, QrCheckStatusCode.REENTRY);
-
-    // 입장스캔O 퇴장스캔0 입장기록있음
-    if (entryPolicyDto.getCheckInAllowed() && entryPolicyDto.getCheckOutAllowed()
-        && hasEntry && !hasExit) {
-      throw new CustomException(HttpStatus.UNAUTHORIZED, "퇴장 처리가 되지 않아 재입장하실 수 없습니다.");
-    } else if (!entryPolicyDto.getCheckInAllowed() && entryPolicyDto.getCheckOutAllowed()
-        && !hasExit) {
-      // 입장스캔X 퇴장스캔0 퇴장 기록 없음
-      throw new CustomException(HttpStatus.UNAUTHORIZED, "퇴장 처리가 되지 않아 재입장하실 수 없습니다.");
-    } else if (entryPolicyDto.getCheckInAllowed() && !entryPolicyDto.getCheckOutAllowed()
-        && !(hasEntry || hasReEntry)) {
-      // 입장스캔O 퇴장스캔X 입장 기록 없음
-      throw new CustomException(HttpStatus.UNAUTHORIZED, "입장 처리가 되지 않아 재입장하실 수 없습니다.");
-    }
-  }
-
-  private void cantReEntry(QrTicket qrTicket, EntryPolicyDto entryPolicyDto) {
-    boolean hasEntry = qrLogService.hasCheckRecord(qrTicket, QrCheckStatusCode.ENTRY);
-    boolean hasExit = qrLogService.hasCheckRecord(qrTicket, QrCheckStatusCode.EXIT);
-
-    // 입장스캔O 퇴장스캔0 입장기록있음
-    if ((entryPolicyDto.getCheckInAllowed() && entryPolicyDto.getCheckOutAllowed() && hasEntry)
-        || (!entryPolicyDto.getCheckInAllowed() && entryPolicyDto.getCheckOutAllowed() && hasExit)
-        || (entryPolicyDto.getCheckInAllowed() && !entryPolicyDto.getCheckOutAllowed() && hasEntry)) {
-      throw new CustomException(HttpStatus.UNAUTHORIZED, "이미 입장 또는 퇴장 완료된 티켓이므로 재입장하실 수 없습니다.");
-    }
-  }
-
   // 검증 완료 후 디비 데이터 저장
-  private LocalDateTime processCheckIn(QrTicket ticket) {
-    // qr코드 상태변경 log
-    qrLogSave(ticket, "CHECKIN");
-    // 체크인 상태변경 log
-    // 체크인 여부 확인
-    LocalDateTime now = LocalDateTime.now();
-    return now;
-  }
-
-  // QR 로그 저장
-  private void qrLogSave(QrTicket qrTicket, String type) {
-//    qrLogService(qrTicket, type);
-  }
-
-  private EntryPolicyDto buildEntryPolicy(QrTicket qrTicket) {
-    EventDetail eventDetail = qrTicket.getEventSchedule().getEvent().getEventDetail();
-
-    // 입장 스캔 여부, 퇴장 스캔 여부, 재입장 가능 여부 정책 dto
-    return EntryPolicyDto.builder()
-        .checkInAllowed(true)
-        .checkOutAllowed(eventDetail.getCheckOutAllowed())
-        .reentryAllowed(eventDetail.getReentryAllowed())
-        .build();
+  private LocalDateTime processCheckIn(QrTicket qrTicket, String checkInType, String entryType) {
+    return qrLogService.entryQrLog(qrTicket, checkInType, entryType);
   }
 }

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketEntryService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketEntryService.java
@@ -5,6 +5,7 @@ import com.fairing.fairplay.attendee.entity.AttendeeTypeCode;
 import com.fairing.fairplay.attendee.repository.AttendeeRepository;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.qr.dto.CheckInRequestDto;
 import com.fairing.fairplay.qr.dto.CheckInResponseDto;
 import com.fairing.fairplay.qr.dto.GuestManualCheckInRequestDto;
 import com.fairing.fairplay.qr.dto.GuestQrCheckInRequestDto;
@@ -22,6 +23,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+/*
+ * 1. 재입장 가능 여부 검토
+ * 2. 최초 입장인지 재입장인지 판단
+ * 3. 코드 스캔 로그 기록
+ * 4. QR 코드 일치 하는 지 검토
+ * 5. QR 티켓 처리
+ * - 중복 스캔 여부 검토 -> 로그 기록 후 예외
+ * - 잘못된 스캔 여부 검토 -> 로그 기록 후 예외
+ * - QR 체크인 로그 기록
+ * */
 @Service
 @RequiredArgsConstructor
 public class QrTicketEntryService {
@@ -32,109 +43,91 @@ public class QrTicketEntryService {
   private final QrLogService qrLogService;
   private final QrEntryValidateService qrEntryValidateService;
 
+  private static final String QR = "QR";
+  private static final String MANUAL = "MANUAL";
+
   // 회원 QR 코드 체크인
   public CheckInResponseDto checkIn(MemberQrCheckInRequestDto dto, CustomUserDetails userDetails) {
     // 예약자 조회
-    Attendee attendee = findAttendeeByReservation(dto.getReservationId());
-    // 예약자와 현재 로그인한 사용자 일치 여부 조회
-    if (!userDetails.getUserId().equals(attendee.getReservation().getUser().getUserId())) {
-      throw new CustomException(HttpStatus.UNAUTHORIZED, "예약자와 현재 로그인한 사용자가 일치하지 않습니다.");
-    }
-    // QR 티켓 조회
-    QrTicket qrTicket = findQrTicket(attendee);
-    // 코드 스캔 기록
-    qrLogService.scannedQrLog(qrTicket, QrActionCode.SCANNED);
-    /*
-    * 1. 재입장 가능 여부 검토 => qrEntryPolicyService
-    * 2. 최초 입장인지 재입장인지 판단 => qrLogService
-    * 3. 코드 스캔 로그 기록 => qrLogService
-    * 4. QR 코드 일치 하는 지 검토 => qrTicketEntryService
-    * 5. QR 티켓 처리 => qrTicketEntryService
-    * - 중복 스캔 여부 검토 -> 로그 기록 후 예외 => qrLogService
-    * - 잘못된 스캔 여부 검토 -> 로그 기록 후 예외 => qrLogService
-    * - QR 체크인 로그 기록 => qrLogService
-    * */
-    // 재입장 가능 여부 검토 - 입장 기록 자체가 있는지 조회
-    qrEntryValidateService.verifyReEntry(qrTicket);
-    // 현재 입장이 최초입장인지 재입장인지 판단 QrCheckStatusCode.ENTRY, rCheckStatusCode.REENTRY
-    String entryType = qrLogService.determineEntryOrReEntry(qrTicket);
-    // qrcode 비교
-    verifyQrCode(qrTicket, dto.getQrCode());
-    // QR 티켓 처리
-    LocalDateTime checkInTime = processCheckIn(qrTicket, QrActionCode.CHECKED_IN, entryType);
-
-    return CheckInResponseDto.builder()
-        .message("체크인 완료되었습니다.")
-        .checkInTime(checkInTime)
+    Attendee attendee = findAttendee(dto.getReservationId(), null);
+    CheckInRequestDto checkInRequestDto = CheckInRequestDto.builder()
+        .attendee(attendee)
+        .requireUserMatch(true)
+        .userDetails(userDetails)
+        .codeType(QR)
+        .codeValue(dto.getQrCode())
+        .qrActionCode(QrActionCode.CHECKED_IN)
         .build();
+
+    return processCheckInCommon(checkInRequestDto);
   }
 
   // 회원 수동 코드 체크인
   public CheckInResponseDto checkIn(MemberManualCheckInRequestDto dto,
       CustomUserDetails userDetails) {
     // 예약자 조회
-    Attendee attendee = findAttendeeByReservation(dto.getReservationId());
-    // 예약자와 현재 로그인한 사용자 일치 여부 조회
-    if (!userDetails.getUserId().equals(attendee.getReservation().getUser().getUserId())) {
-      throw new CustomException(HttpStatus.UNAUTHORIZED, "예약자와 현재 로그인한 사용자가 일치하지 않습니다.");
-    }
-    // QR 티켓 조회
-    QrTicket qrTicket = findQrTicket(attendee);
-    // 재입장 여부 검토
-
-    // 수동 코드 비교
-    verifyManualCode(qrTicket, dto.getManualCode());
-    // QR 티켓 처리
-    LocalDateTime checkInTime = processCheckIn(qrTicket, QrActionCode.MANUAL_CHECKED_IN,
-        true ? QrCheckStatusCode.REENTRY : QrCheckStatusCode.ENTRY);
-    return CheckInResponseDto.builder()
-        .message("체크인 완료되었습니다.")
-        .checkInTime(checkInTime)
+    Attendee attendee = findAttendee(dto.getReservationId(), null);
+    CheckInRequestDto checkInRequestDto = CheckInRequestDto.builder()
+        .attendee(attendee)
+        .requireUserMatch(true)
+        .userDetails(userDetails)
+        .codeType(MANUAL)
+        .codeValue(dto.getManualCode())
+        .qrActionCode(QrActionCode.MANUAL_CHECKED_IN)
         .build();
+
+    return processCheckInCommon(checkInRequestDto);
   }
 
   // 비회원 QR 코드 체크인
   public CheckInResponseDto checkIn(GuestQrCheckInRequestDto dto) {
     // qr 티켓 링크 token 조회
     QrTicketRequestDto qrLinkTokenInfo = codeValidator.decodeToDto(dto.getQrLinkToken());
-    // 참석자 조회
-    Attendee attendee = findAttendeeByAttendee(qrLinkTokenInfo.getAttendeeId());
-    // qr 티켓 조회
-    QrTicket qrTicket = findQrTicket(attendee);
-    // 코드 스캔 기록
-    qrLogService.scannedQrLog(qrTicket, QrActionCode.SCANNED);
-    // 재입장 여부 검토
 
-    // qrcode 비교
-    verifyQrCode(qrTicket, dto.getQrCode());
-    // QR 티켓 처리
-    LocalDateTime checkInTime = processCheckIn(qrTicket, QrActionCode.CHECKED_IN,
-        true ? QrCheckStatusCode.REENTRY : QrCheckStatusCode.ENTRY);
-    return CheckInResponseDto.builder()
-        .message("체크인 완료되었습니다.")
-        .checkInTime(checkInTime)
+    // 예약자 조회
+    Attendee attendee = findAttendee(null, qrLinkTokenInfo.getAttendeeId());
+    CheckInRequestDto checkInRequestDto = CheckInRequestDto.builder()
+        .attendee(attendee)
+        .requireUserMatch(false)
+        .userDetails(null)
+        .codeType(QR)
+        .codeValue(dto.getQrCode())
+        .qrActionCode(QrActionCode.CHECKED_IN)
         .build();
+
+    return processCheckInCommon(checkInRequestDto);
   }
 
   // 비회원 수동 코드 체크인
   public CheckInResponseDto checkIn(GuestManualCheckInRequestDto dto) {
     // qr 티켓 링크 token 조회
     QrTicketRequestDto qrLinkTokenInfo = codeValidator.decodeToDto(dto.getQrLinkToken());
-    // 참석자 조회
-    Attendee attendee = findAttendeeByAttendee(qrLinkTokenInfo.getAttendeeId());
-    // qr 티켓 조회
-    QrTicket qrTicket = findQrTicket(attendee);
-    // 재입장 여부 검토
 
-    // 수동 코드 비교
-    verifyManualCode(qrTicket, dto.getManualCode());
-    // QR 티켓 처리
-    LocalDateTime checkInTime = processCheckIn(qrTicket, QrActionCode.MANUAL_CHECKED_IN,
-        true ? QrCheckStatusCode.REENTRY : QrCheckStatusCode.ENTRY);
-    return CheckInResponseDto.builder()
-        .message("체크인 완료되었습니다.")
-        .checkInTime(checkInTime)
+    // 예약자 조회
+    Attendee attendee = findAttendee(null, qrLinkTokenInfo.getAttendeeId());
+    CheckInRequestDto checkInRequestDto = CheckInRequestDto.builder()
+        .attendee(attendee)
+        .requireUserMatch(false)
+        .userDetails(null)
+        .codeType(MANUAL)
+        .codeValue(dto.getManualCode())
+        .qrActionCode(QrActionCode.MANUAL_CHECKED_IN)
         .build();
+
+    return processCheckInCommon(checkInRequestDto);
+  }
+
+  /**
+   * Attendee 조회 (회원은 reservationId, 비회원은 attendeeId로)
+   */
+  private Attendee findAttendee(Long reservationId, Long attendeeId) {
+    if (reservationId != null) {
+      return findAttendeeByReservation(reservationId);
+    }
+    if (attendeeId != null) {
+      return findAttendeeByAttendee(attendeeId);
+    }
+    throw new CustomException(HttpStatus.BAD_REQUEST, "reservationId 또는 attendeeId 중 하나는 필수입니다.");
   }
 
   // 회원 attendee 조회
@@ -150,12 +143,26 @@ public class QrTicketEntryService {
         .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "참석자를 조회하지 못했습니다."));
   }
 
-  // QR 티켓 조회
+  /**
+   * 로그인 사용자와 참석자 일치 여부 확인
+   */
+  private void validateUserMatch(Attendee attendee, CustomUserDetails userDetails) {
+    if (!attendee.getReservation().getUser().getUserId().equals(userDetails.getUserId())) {
+      throw new CustomException(HttpStatus.FORBIDDEN, "참석자와 로그인한 사용자가 일치하지 않습니다.");
+    }
+  }
+
+  /**
+   * QR 티켓 조회
+   */
   private QrTicket findQrTicket(Attendee attendee) {
     return qrTicketRepository.findByAttendee(attendee)
         .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "예약된 QR 티켓을 찾지 못했습니다."));
   }
 
+  /**
+   * 코드 검증
+   */
   // QR 코드 검증
   private void verifyQrCode(QrTicket qrTicket, String qrCode) {
     if (!qrTicket.getActive()) {
@@ -176,8 +183,49 @@ public class QrTicketEntryService {
     }
   }
 
+  /**
+   * 체크인 공통 로직
+   */
+  private CheckInResponseDto processCheckInCommon(CheckInRequestDto dto) {
+    if (dto.isRequireUserMatch()) {
+      // 회원, 비회원 여부에 따라 참석자=로그인한 사용자 여부 조회
+      validateUserMatch(dto.getAttendee(), dto.getUserDetails());
+    }
+    // QR 티켓 조회
+    QrTicket qrTicket = findQrTicket(dto.getAttendee());
+    // QrActionCode 검토
+    QrActionCode qrActionCode = qrEntryValidateService.validateQrActionCode(QrActionCode.SCANNED);
+    // 중복 스캔 -> QrLog: invalid, QrChecktLog: duplicate 저장
+    qrEntryValidateService.preventDuplicateScan(qrTicket, qrActionCode.getCode());
+    // 코드 스캔 기록
+    qrLogService.scannedQrLog(qrTicket, qrActionCode);
+    // 재입장 가능 여부 검토 - 입장 기록 자체가 있는지 조회
+    qrEntryValidateService.verifyReEntry(qrTicket);
+    // 현재 입장이 최초입장인지 재입장인지 판단 QrCheckStatusCode.ENTRY, rCheckStatusCode.REENTRY
+    String entryType = qrLogService.determineEntryOrReEntry(qrTicket);
+    // 코드 비교
+    if (QR.equals(dto.getCodeType())) {
+      verifyQrCode(qrTicket, dto.getCodeValue());
+    } else {
+      verifyManualCode(qrTicket, dto.getCodeValue());
+    }
+    // QR 티켓 처리
+    LocalDateTime checkInTime = processCheckIn(qrTicket, dto.getQrActionCode(), entryType);
+    return CheckInResponseDto.builder()
+        .message("체크인 완료되었습니다.")
+        .checkInTime(checkInTime)
+        .build();
+  }
+
   // 검증 완료 후 디비 데이터 저장
   private LocalDateTime processCheckIn(QrTicket qrTicket, String checkInType, String entryType) {
-    return qrLogService.entryQrLog(qrTicket, checkInType, entryType);
+    // actionCodeType = CHECKED_IN, MANUAL_CHECKED_IN
+    QrActionCode qrActionCode = qrEntryValidateService.validateQrActionCode(checkInType);
+    // checkStatusCode = ENTRY, REENTRY
+    QrCheckStatusCode qrCheckStatusCode = qrEntryValidateService.validateQrCheckStatusCode(
+        entryType);
+    // 잘못된 입퇴장 스캔 -> ENTRY, REENTRY
+    qrEntryValidateService.preventInvalidScan(qrTicket, qrCheckStatusCode.getCode());
+    return qrLogService.entryQrLog(qrTicket, qrActionCode, qrCheckStatusCode);
   }
 }

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketEntryService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketEntryService.java
@@ -195,14 +195,14 @@ public class QrTicketEntryService {
     QrTicket qrTicket = findQrTicket(dto.getAttendee());
     // QrActionCode 검토
     QrActionCode qrActionCode = qrEntryValidateService.validateQrActionCode(QrActionCode.SCANNED);
-    // 중복 스캔 -> QrLog: invalid, QrChecktLog: duplicate 저장
-    qrEntryValidateService.preventDuplicateScan(qrTicket, qrActionCode.getCode());
     // 코드 스캔 기록
     qrLogService.scannedQrLog(qrTicket, qrActionCode);
     // 재입장 가능 여부 검토 - 입장 기록 자체가 있는지 조회
     qrEntryValidateService.verifyReEntry(qrTicket);
     // 현재 입장이 최초입장인지 재입장인지 판단 QrCheckStatusCode.ENTRY, rCheckStatusCode.REENTRY
     String entryType = qrLogService.determineEntryOrReEntry(qrTicket);
+    // 중복 스캔 -> QrLog: invalid, QrChecktLog: duplicate 저장
+    qrEntryValidateService.preventDuplicateScan(qrTicket, entryType);
     // 코드 비교
     if (QR.equals(dto.getCodeType())) {
       verifyQrCode(qrTicket, dto.getCodeValue());

--- a/src/main/java/com/fairing/fairplay/qr/util/CodeGenerator.java
+++ b/src/main/java/com/fairing/fairplay/qr/util/CodeGenerator.java
@@ -87,10 +87,6 @@ public class CodeGenerator {
     }
 
   }
-  // 토큰 문자열 -> long[]으로 변환
-  private long[] decodeToken(String token) {
-    return hashids.decode(token);
-  }
 
   // DTO 값이 null일 때 오류 방지용
   private long safeLong(Long val) {

--- a/src/main/java/com/fairing/fairplay/qr/util/CodeValidator.java
+++ b/src/main/java/com/fairing/fairplay/qr/util/CodeValidator.java
@@ -2,7 +2,6 @@ package com.fairing.fairplay.qr.util;
 
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
-import com.fairing.fairplay.qr.repository.QrTicketRepository;
 import lombok.RequiredArgsConstructor;
 import org.hashids.Hashids;
 import org.springframework.http.HttpStatus;
@@ -13,7 +12,6 @@ import org.springframework.stereotype.Component;
 public class CodeValidator {
 
   private final Hashids hashids;
-  private final QrTicketRepository qrTicketRepository;
 
   // QrUrlToken 검증
   public QrTicketRequestDto decodeToDto(String token) {


### PR DESCRIPTION
## 변경 사항
- 행사 관련 입퇴장, 재입장 가능 정책 검증 추가
# 입장/퇴장/재입장 스캔 정책

| 구분         | 스캔 종류    | 조건 및 설명                                            |
|--------------|-------------|-------------------------------------------------------|
| **재입장 가능** | 입장, 퇴장  | 입장 스캔: 이전 기록 없으면 가능                      |
|              |             | 재입장 스캔: 이전 퇴장 기록 있으면 가능 (필요 시 입장 기록 삭제) |
|              |             | 퇴장 스캔: 이전 입장 또는 재입장 기록 있어야 가능      |
|              | 입장만      | 입장 스캔: 이전 기록 없으면 언제나 가능                |
|              |             | 재입장 스캔: 이전 입장 기록 있어야 가능                |
|              | 퇴장만      | 퇴장 스캔: 이전 기록 없거나 퇴장 기록 있으면 가능       |
|              |             |   (퇴장 기록 있으면 입장한 것으로 판단)                   |
| **재입장 불가능** | 입장, 퇴장  | 입장 스캔: 이전 기록 없으면 가능                      |
|              |             | 재입장 스캔: 이전 입장 기록 있으면 불가능               |
|              |             | 퇴장 스캔: 이전 입장 기록 있어야 하며, 이전 퇴장 기록 있으면 불가능 |
|              | 입장만      | 입장 스캔: 이전 기록 없으면 언제나 가능                |
|              |             | 재입장 스캔: 이전 입장 기록 있으면 불가능               |
|              | 퇴장만      | 퇴장 스캔: 이전 기록 없으면 가능                       |
|              |             |   단, 퇴장 기록 하나라도 있으면 재입장 불가               |

## 추가 사항
- QR 코드 스캔, 입장, 퇴장 관련 로그 테스트 필요
- 프론트 API 연결 후 테스트 예정

## 관련 이슈
#36  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 멤버 및 게스트의 QR 코드 스캔 및 수기 입력 체크인 API 엔드포인트 4종 추가
  * 체크인 요청 및 입장 정책 관련 데이터 객체 도입
  * QR 티켓 발행 및 체크인 로그 기록 기능 강화, 배치 처리 및 상세 기록 지원
  * 입장 정책 검증 서비스 추가로 재입장 및 스캔 상태 검증 체계화

* **버그 수정**
  * 사용자와 참석자 일치 검증 강화로 보안성 향상
  * 중복 스캔 및 잘못된 스캔 방지 로직 별도 서비스 분리로 안정성 개선

* **리팩터**
  * 멤버·게스트, QR·수기 체크인 로직 통합으로 코드 흐름 간소화 및 유지보수 용이
  * 로그 기록 및 검증 로직 전담 서비스 분리로 책임 명확화
  * QR 티켓 배치 생성 시 발행된 티켓 필터링 및 발행 로그 기록 기능 추가

* **기타**
  * 불필요한 필드, 메서드, 주석 및 의존성 제거로 코드 정리 및 가독성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->