### PR TITLE
feat: 관리자 예약 통계 기능 추가 

### DIFF
--- a/src/main/java/com/fairing/fairplay/statistics/controller/AdminReservationDashboardController.java
+++ b/src/main/java/com/fairing/fairplay/statistics/controller/AdminReservationDashboardController.java
@@ -9,6 +9,8 @@ import com.fairing.fairplay.statistics.service.reservation.AdminReservationServi
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,7 +43,7 @@ public class AdminReservationDashboardController {
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             @RequestParam(required = false) String mainCategory,
             @RequestParam(required = false) String subCategory,
-            Pageable pageable
+            @PageableDefault(size = 10, sort = "rank", direction = Sort.Direction.ASC) Pageable pageable
     ) {
         return adminReservationService.getEventsByCategory(startDate, endDate, mainCategory, subCategory, pageable);
     }
@@ -66,14 +68,15 @@ public class AdminReservationDashboardController {
 
 
     @GetMapping("/search")
-    public List<AdminReservationStatsListDto> getSearchReservation(
+    public Page<AdminReservationStatsListDto> getSearchReservation(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             @RequestParam(required = false) String mainCategory,
             @RequestParam(required = false) String subCategory,
-            @RequestParam(required = true) String keyword
+            @RequestParam(required = true) String keyword,
+            @PageableDefault(size = 10, sort = "rank", direction = Sort.Direction.ASC) Pageable pageable // 기본 페이징 조건
     ) {
-        return  adminReservationService.searchEvents(startDate,  endDate, keyword,  mainCategory, subCategory);
+        return  adminReservationService.searchEvents(startDate,  endDate, keyword,  mainCategory, subCategory,pageable);
     }
 
     @GetMapping("/summary")

--- a/src/main/java/com/fairing/fairplay/statistics/controller/AdminReservationDashboardController.java
+++ b/src/main/java/com/fairing/fairplay/statistics/controller/AdminReservationDashboardController.java
@@ -1,0 +1,89 @@
+package com.fairing.fairplay.statistics.controller;
+
+
+import com.fairing.fairplay.statistics.dto.reservation.AdminReservationStatsListDto;
+import com.fairing.fairplay.statistics.dto.reservation.AdminReservationSummaryDto;
+import com.fairing.fairplay.statistics.dto.reservation.ReservationDailyTrendDto;
+import com.fairing.fairplay.statistics.dto.reservation.ReservationMonthlyTrendDto;
+import com.fairing.fairplay.statistics.service.reservation.AdminReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/reservation")
+@RequiredArgsConstructor
+public class AdminReservationDashboardController {
+
+    private final AdminReservationService adminReservationService;
+
+    /**
+     * 예약 목록 - 페이징 조회
+     *
+     * @param startDate    조회 시작일 (yyyy-MM-dd)
+     * @param endDate      조회 종료일 (yyyy-MM-dd)
+     * @param mainCategory 메인 카테고리 (optional)
+     * @param subCategory  서브 카테고리 (optional)
+     * @param pageable     페이징 정보 (page, size, sort)
+     * @return 페이징된 이벤트 인기 통계 DTO 페이지
+     */
+    @GetMapping("/list")
+    public Page<AdminReservationStatsListDto> getAggregatedPopularity(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @RequestParam(required = false) String mainCategory,
+            @RequestParam(required = false) String subCategory,
+            Pageable pageable
+    ) {
+        return adminReservationService.getEventsByCategory(startDate, endDate, mainCategory, subCategory, pageable);
+    }
+
+    @GetMapping("/trend-month")
+    public List<ReservationMonthlyTrendDto> getMonthTrend(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+
+    ) {
+        return  adminReservationService.monthlyTrend(startDate,  endDate);
+    }
+
+    @GetMapping("/trend-daily")
+    public List<ReservationDailyTrendDto> getDailyTrend(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+
+    ) {
+        return  adminReservationService.dailyTrend(startDate,  endDate);
+    }
+
+
+    @GetMapping("/search")
+    public List<AdminReservationStatsListDto> getSearchReservation(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @RequestParam(required = false) String mainCategory,
+            @RequestParam(required = false) String subCategory,
+            @RequestParam(required = true) String keyword
+    ) {
+        return  adminReservationService.searchEvents(startDate,  endDate, keyword,  mainCategory, subCategory);
+    }
+
+    @GetMapping("/summary")
+    public AdminReservationSummaryDto getReportPopularity(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate){
+        return adminReservationService.getReservationSummary(startDate, endDate );
+    }
+
+
+
+
+}

--- a/src/main/java/com/fairing/fairplay/statistics/dto/reservation/AdminReservationStatsByCategoryDto.java
+++ b/src/main/java/com/fairing/fairplay/statistics/dto/reservation/AdminReservationStatsByCategoryDto.java
@@ -1,0 +1,15 @@
+package com.fairing.fairplay.statistics.dto.reservation;
+
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminReservationStatsByCategoryDto {
+
+    private Integer totalReservation;
+    private String mainCategory;
+}

--- a/src/main/java/com/fairing/fairplay/statistics/dto/reservation/AdminReservationStatsListDto.java
+++ b/src/main/java/com/fairing/fairplay/statistics/dto/reservation/AdminReservationStatsListDto.java
@@ -1,0 +1,30 @@
+package com.fairing.fairplay.statistics.dto.reservation;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+
+public class AdminReservationStatsListDto {
+    private Long eventId;
+    private String eventTitle;
+
+    @Builder.Default
+    private Long totalSales = 0L;
+
+    @Builder.Default
+    private Long reservationCount = 0L;
+
+    private String mainCategory;
+    private String subCategory;
+    @Builder.Default
+    private Integer rank = 0;
+
+    @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime calculatedAt;
+}

--- a/src/main/java/com/fairing/fairplay/statistics/dto/reservation/AdminReservationSummaryDto.java
+++ b/src/main/java/com/fairing/fairplay/statistics/dto/reservation/AdminReservationSummaryDto.java
@@ -1,0 +1,20 @@
+package com.fairing.fairplay.statistics.dto.reservation;
+
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminReservationSummaryDto {
+    private Integer totalReservations;
+    private BigDecimal totalSales;
+    private Integer totalCancellations;
+    private BigDecimal avgSales;
+    private List<AdminReservationStatsByCategoryDto> categoryTrend;
+}

--- a/src/main/java/com/fairing/fairplay/statistics/dto/reservation/ReservationMonthlyTrendDto.java
+++ b/src/main/java/com/fairing/fairplay/statistics/dto/reservation/ReservationMonthlyTrendDto.java
@@ -1,0 +1,14 @@
+package com.fairing.fairplay.statistics.dto.reservation;
+
+import java.time.YearMonth;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReservationMonthlyTrendDto {
+    private YearMonth yearMonth;
+    private Long reservations;
+}

--- a/src/main/java/com/fairing/fairplay/statistics/repository/dailystats/DailyStatsCustomRepository.java
+++ b/src/main/java/com/fairing/fairplay/statistics/repository/dailystats/DailyStatsCustomRepository.java
@@ -1,10 +1,31 @@
 package com.fairing.fairplay.statistics.repository.dailystats;
 
 
+
+import com.fairing.fairplay.statistics.dto.reservation.AdminReservationStatsByCategoryDto;
+import com.fairing.fairplay.statistics.dto.reservation.AdminReservationStatsListDto;
 import com.fairing.fairplay.statistics.entity.reservation.EventDailyStatistics;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.time.LocalDate;
 import java.util.List;
 
 public interface DailyStatsCustomRepository {
     List<EventDailyStatistics> calculate(LocalDate targetDate);
+    List<AdminReservationStatsByCategoryDto> aggregatedReservationByCategory(
+            LocalDate startDate,
+            LocalDate endDate
+
+    );
+
+    List<AdminReservationStatsListDto> searchEventReservationWithRank(LocalDate startDate, LocalDate endDate, String keyword, String mainCategory, String subCategory);
+
+    Page<AdminReservationStatsListDto> aggregatedPopularity(
+            LocalDate startDate,
+            LocalDate endDate,
+            String mainCategory,
+            String subCategory,
+            Pageable pageable  // 페이징 정보 추가
+    );
 }

--- a/src/main/java/com/fairing/fairplay/statistics/repository/dailystats/DailyStatsCustomRepository.java
+++ b/src/main/java/com/fairing/fairplay/statistics/repository/dailystats/DailyStatsCustomRepository.java
@@ -19,7 +19,7 @@ public interface DailyStatsCustomRepository {
 
     );
 
-    List<AdminReservationStatsListDto> searchEventReservationWithRank(LocalDate startDate, LocalDate endDate, String keyword, String mainCategory, String subCategory);
+    Page<AdminReservationStatsListDto> searchEventReservationWithRank(LocalDate startDate, LocalDate endDate, String keyword, String mainCategory, String subCategory, Pageable pageable);
 
     Page<AdminReservationStatsListDto> aggregatedPopularity(
             LocalDate startDate,

--- a/src/main/java/com/fairing/fairplay/statistics/repository/dailystats/DailyStatsCustomRepositoryImpl.java
+++ b/src/main/java/com/fairing/fairplay/statistics/repository/dailystats/DailyStatsCustomRepositoryImpl.java
@@ -145,7 +145,7 @@ public class DailyStatsCustomRepositoryImpl implements DailyStatsCustomRepositor
                 .from(eds)
                 .leftJoin(d).on(d.event.eventId.eq(eds.eventId))
                 .where(builder)
-                .groupBy(eds.eventId,  d.mainCategory)
+                .groupBy(d.mainCategory)
                 .fetch();
     }
 
@@ -188,7 +188,9 @@ public class DailyStatsCustomRepositoryImpl implements DailyStatsCustomRepositor
                 ))
                 .from(eps)
                 .leftJoin(d).on(d.event.eventId.eq(eps.eventId))
-                .leftJoin(edss).on(edss.eventId.eq(eps.eventId))
+                .leftJoin(edss).on(edss.eventId.eq(eps.eventId)
+                        .and(edss.statDate.goe(startDate))
+                        .and(edss.statDate.lt(endDate.plusDays(1))))
                 .where(builder)
                 .groupBy(
                         eps.eventId,
@@ -253,12 +255,14 @@ public class DailyStatsCustomRepositoryImpl implements DailyStatsCustomRepositor
                         d.mainCategory,
                         d.subCategory,
                         Expressions.numberTemplate(Integer.class,
-                                "ROW_NUMBER() OVER (ORDER BY {0} DESC)", eps.viewCount.sum().coalesce(0L)),
+                                "ROW_NUMBER() OVER (ORDER BY {0} DESC)", eps.reservationCount.sum().coalesce(0L)),
                         eps.calculatedAt.max()
                 ))
                 .from(eps)
                 .leftJoin(d).on(d.event.eventId.eq(eps.eventId))
-                .leftJoin(edss).on(edss.eventId.eq(eps.eventId))
+                .leftJoin(edss).on(edss.eventId.eq(eps.eventId)
+                        .and(edss.statDate.goe(startDate))
+                        .and(edss.statDate.lt(endDate.plusDays(1))))
                 .where(builder)
                 .groupBy(eps.eventId, eps.eventTitle,d.mainCategory, d.subCategory)
                 .orderBy(eps.reservationCount.sum().desc())

--- a/src/main/java/com/fairing/fairplay/statistics/repository/dailystats/DailyStatsCustomRepositoryImpl.java
+++ b/src/main/java/com/fairing/fairplay/statistics/repository/dailystats/DailyStatsCustomRepositoryImpl.java
@@ -1,13 +1,26 @@
 package com.fairing.fairplay.statistics.repository.dailystats;
 
+import com.fairing.fairplay.event.entity.QEventDetail;
+import com.fairing.fairplay.statistics.dto.event.EventPopularityStatisticsListDto;
+import com.fairing.fairplay.statistics.dto.reservation.AdminReservationStatsByCategoryDto;
+import com.fairing.fairplay.statistics.dto.reservation.AdminReservationStatsListDto;
+import com.fairing.fairplay.statistics.entity.event.QEventPopularityStatistics;
 import com.fairing.fairplay.statistics.entity.reservation.EventDailyStatistics;
 import com.fairing.fairplay.reservation.entity.QReservation;
 import com.fairing.fairplay.reservation.entity.QReservationStatusCode;
 import com.fairing.fairplay.attendee.entity.QAttendee;
 import com.fairing.fairplay.qr.entity.QQrCheckLog;
+import com.fairing.fairplay.statistics.entity.reservation.QEventDailyStatistics;
+import com.fairing.fairplay.statistics.entity.sales.QEventDailySalesStatistics;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -104,4 +117,152 @@ public class DailyStatsCustomRepositoryImpl implements DailyStatsCustomRepositor
 
         return new ArrayList<>(map.values());
     }
+
+    @Override
+    public List<AdminReservationStatsByCategoryDto> aggregatedReservationByCategory(
+            LocalDate startDate,
+            LocalDate endDate
+
+
+    ) {
+        QEventDailyStatistics eds = QEventDailyStatistics.eventDailyStatistics;
+        QEventDetail d = QEventDetail.eventDetail;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(
+                eds.statDate.goe(LocalDate.from(startDate.atStartOfDay()))
+                        .and(eds.statDate.lt(LocalDate.from(endDate.plusDays(1).atStartOfDay())))
+        );
+
+
+
+        return queryFactory
+                .select(Projections.constructor(AdminReservationStatsByCategoryDto.class,
+                        eds.reservationCount.sum().coalesce(0),
+                        d.mainCategory
+
+                ))
+                .from(eds)
+                .leftJoin(d).on(d.event.eventId.eq(eds.eventId))
+                .where(builder)
+                .groupBy(eds.eventId,  d.mainCategory)
+                .fetch();
+    }
+
+    /**
+     * 검색
+     * */
+    @Override
+    public List<AdminReservationStatsListDto> searchEventReservationWithRank(LocalDate startDate, LocalDate endDate, String keyword, String mainCategory, String subCategory) {
+        QEventPopularityStatistics eps = QEventPopularityStatistics.eventPopularityStatistics;
+        QEventDetail d = QEventDetail.eventDetail;
+        QEventDailySalesStatistics edss = QEventDailySalesStatistics.eventDailySalesStatistics;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(
+                eps.calculatedAt.goe(startDate.atStartOfDay())
+                        .and(eps.calculatedAt.lt(endDate.plusDays(1).atStartOfDay()))
+        );
+
+        if (keyword != null && !keyword.isBlank()) {
+            builder.and(eps.eventTitle.containsIgnoreCase(keyword));
+        }
+        if (mainCategory != null && !mainCategory.isBlank()) {
+            builder.and(d.mainCategory.groupName.stringValue().eq(mainCategory));
+        }
+        if (subCategory != null && !subCategory.isBlank()) {
+            builder.and(d.subCategory.categoryName.stringValue().eq(subCategory));
+        }
+
+        return queryFactory
+                .select(Projections.constructor(AdminReservationStatsListDto.class,
+                        eps.eventId,
+                        eps.eventTitle,
+                        eps.reservationCount.sum().coalesce(0L),
+                        edss.totalSales.sum().coalesce(0L),
+                        d.mainCategory,
+                        d.subCategory,
+                        Expressions.numberTemplate(Integer.class,
+                                "ROW_NUMBER() OVER (ORDER BY {0} DESC)", eps.viewCount.sum().coalesce(0L)),
+                        eps.calculatedAt.max()
+                ))
+                .from(eps)
+                .leftJoin(d).on(d.event.eventId.eq(eps.eventId))
+                .leftJoin(edss).on(edss.eventId.eq(eps.eventId))
+                .where(builder)
+                .groupBy(
+                        eps.eventId,
+                        eps.eventTitle,
+                        d.mainCategory,
+                        d.subCategory
+                )
+                .orderBy(eps.reservationCount.sum().desc())
+                .fetch();
+    }
+
+    /***
+     * 행사별 예약 순위
+     *
+     */
+    @Override
+    public Page<AdminReservationStatsListDto> aggregatedPopularity(
+            LocalDate startDate,
+            LocalDate endDate,
+            String mainCategory,
+            String subCategory,
+            Pageable pageable  // 페이징 정보 추가
+    ) {
+        QEventPopularityStatistics eps = QEventPopularityStatistics.eventPopularityStatistics;
+        QEventDetail d = QEventDetail.eventDetail;
+        QEventDailySalesStatistics edss = QEventDailySalesStatistics.eventDailySalesStatistics;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(
+                eps.calculatedAt.goe(startDate.atStartOfDay())
+                        .and(eps.calculatedAt.lt(endDate.plusDays(1).atStartOfDay()))
+        );
+
+        if (mainCategory != null && !mainCategory.isBlank()) {
+            builder.and(d.mainCategory.groupName.stringValue().eq(mainCategory));
+        }
+
+        if (subCategory != null && !subCategory.isBlank()) {
+            builder.and(d.subCategory.categoryName.stringValue().eq(subCategory));
+        }
+
+        // 데이터 조회 쿼리
+        List<AdminReservationStatsListDto> content = queryFactory
+                .select(Projections.constructor(AdminReservationStatsListDto.class,
+                        eps.eventId,
+                        eps.eventTitle,
+                        eps.reservationCount.sum().coalesce(0L),
+                        edss.totalSales.sum().coalesce(0L),
+                        d.mainCategory,
+                        d.subCategory,
+                        Expressions.numberTemplate(Integer.class,
+                                "ROW_NUMBER() OVER (ORDER BY {0} DESC)", eps.viewCount.sum().coalesce(0L)),
+                        eps.calculatedAt.max()
+                ))
+                .from(eps)
+                .leftJoin(d).on(d.event.eventId.eq(eps.eventId))
+                .leftJoin(edss).on(edss.eventId.eq(eps.eventId))
+                .where(builder)
+                .groupBy(eps.eventId, eps.eventTitle,d.mainCategory, d.subCategory)
+                .orderBy(eps.reservationCount.sum().desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 카운트 쿼리 (group by가 있으므로 countDistinct 사용 권장)
+        Long total = queryFactory
+                .select(eps.eventId.countDistinct())
+                .from(eps)
+                .leftJoin(d).on(d.event.eventId.eq(eps.eventId))
+                .leftJoin(edss).on(edss.eventId.eq(eps.eventId))
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0);
+    }
+
 }

--- a/src/main/java/com/fairing/fairplay/statistics/repository/dailystats/EventDailyStatisticsRepository.java
+++ b/src/main/java/com/fairing/fairplay/statistics/repository/dailystats/EventDailyStatisticsRepository.java
@@ -6,8 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDate;
 import java.util.List;
 
-public interface EventDailyStatisticsRepository extends JpaRepository<EventDailyStatistics, Long>,DailyStatsCustomRepository {
+public interface EventDailyStatisticsRepository extends JpaRepository<EventDailyStatistics, Long> {
     List<EventDailyStatistics> findByEventIdOrderByStatDate(Long eventId);
 
     List<EventDailyStatistics> findByEventIdAndStatDateBetweenOrderByStatDate(Long eventId, LocalDate start, LocalDate end);
+    List<EventDailyStatistics> findByStatDateBetweenOrderByStatDate(LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/fairing/fairplay/statistics/repository/salesstats/EventDailySalesStatisticsRepository.java
+++ b/src/main/java/com/fairing/fairplay/statistics/repository/salesstats/EventDailySalesStatisticsRepository.java
@@ -1,7 +1,12 @@
 package com.fairing.fairplay.statistics.repository.salesstats;
 
+import com.fairing.fairplay.statistics.entity.reservation.EventDailyStatistics;
 import com.fairing.fairplay.statistics.entity.sales.EventDailySalesStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface EventDailySalesStatisticsRepository extends JpaRepository<EventDailySalesStatistics, Long> {
+    List<EventDailySalesStatistics> findByStatDateBetweenOrderByStatDate(LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/fairing/fairplay/statistics/service/reservation/AdminReservationService.java
+++ b/src/main/java/com/fairing/fairplay/statistics/service/reservation/AdminReservationService.java
@@ -1,0 +1,133 @@
+package com.fairing.fairplay.statistics.service.reservation;
+
+
+import com.fairing.fairplay.statistics.dto.event.EventPopularityStatisticsListDto;
+import com.fairing.fairplay.statistics.dto.reservation.*;
+import com.fairing.fairplay.statistics.entity.reservation.EventDailyStatistics;
+import com.fairing.fairplay.statistics.entity.sales.EventDailySalesStatistics;
+import com.fairing.fairplay.statistics.repository.dailystats.DailyStatsCustomRepository;
+import com.fairing.fairplay.statistics.repository.dailystats.EventDailyStatisticsRepository;
+import com.fairing.fairplay.statistics.repository.eventstats.EventPopularityStatsCustomRepositoryImpl;
+import com.fairing.fairplay.statistics.repository.salesstats.EventDailySalesStatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AdminReservationService {
+
+    private final EventDailyStatisticsRepository eventDailyStatisticsRepository;
+    private final EventDailySalesStatisticsRepository eventDailySalesStatisticsRepository;
+    private final DailyStatsCustomRepository dailyStatsCustomRepository;
+
+    public AdminReservationSummaryDto getReservationSummary(LocalDate start, LocalDate end) {
+        // 날짜 범위 검증
+        if (start.isAfter(end)) {
+            throw new IllegalArgumentException("시작일이 종료일보다 늦을 수 없습니다.");
+        }
+
+        List<EventDailyStatistics> dailyReservationList = eventDailyStatisticsRepository.findByStatDateBetweenOrderByStatDate(start,end);
+        int totalReservations = dailyReservationList.stream().mapToInt(EventDailyStatistics::getReservationCount).sum();
+        int totalCancellations = dailyReservationList.stream().mapToInt(EventDailyStatistics::getCancellationCount).sum();
+
+        List<EventDailySalesStatistics> dailySalesList  =  eventDailySalesStatisticsRepository.findByStatDateBetweenOrderByStatDate(start , end);
+        BigDecimal  totalSales = dailySalesList.stream().map(EventDailySalesStatistics::getTotalSales).map(BigDecimal::valueOf) // Long → BigDecimal 변환
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        long totalCount = dailySalesList.stream()
+                .mapToLong(EventDailySalesStatistics::getTotalCount)
+                .sum();
+
+        BigDecimal avgSales = totalCount > 0
+                ? totalSales.divide(BigDecimal.valueOf(totalCount), 2, RoundingMode.HALF_UP)
+                : BigDecimal.ZERO;
+
+        List<AdminReservationStatsByCategoryDto> categoryTrend = dailyStatsCustomRepository.aggregatedReservationByCategory(start,end);
+
+        return AdminReservationSummaryDto.builder()
+                .totalReservations(totalReservations)
+                .totalCancellations(totalCancellations)
+                .totalSales(totalSales)
+                .avgSales(avgSales)
+                .categoryTrend(categoryTrend)
+                .build();
+    }
+
+    public List<ReservationDailyTrendDto> dailyTrend(LocalDate start, LocalDate end){
+
+        if (start.isAfter(end)) {
+            throw new IllegalArgumentException("시작일이 종료일보다 늦을 수 없습니다.");
+        }
+
+        List<EventDailyStatistics> dailyReservationList = eventDailyStatisticsRepository.findByStatDateBetweenOrderByStatDate(start,end);
+
+        return dailyReservationList.stream()
+                .map(s -> ReservationDailyTrendDto.builder()
+                        .date(s.getStatDate())
+                        .reservations(s.getReservationCount())
+                        .build())
+                .toList();
+    }
+
+    public List<ReservationMonthlyTrendDto> monthlyTrend(LocalDate start, LocalDate end) {
+        if (start.isAfter(end)) {
+            throw new IllegalArgumentException("시작일이 종료일보다 늦을 수 없습니다.");
+        }
+
+        List<EventDailyStatistics> dailyReservationList =
+                eventDailyStatisticsRepository.findByStatDateBetweenOrderByStatDate(start, end);
+
+        // 월별 그룹화
+        Map<YearMonth, Long> monthlyReservations = dailyReservationList.stream()
+                .collect(Collectors.groupingBy(
+                        s -> YearMonth.from(s.getStatDate()), // 월별 키
+                        Collectors.summingLong(EventDailyStatistics::getReservationCount)
+                ));
+
+        // DTO 변환
+        return monthlyReservations.entrySet().stream()
+                .map(e -> ReservationMonthlyTrendDto.builder()
+                        .yearMonth(e.getKey())
+                        .reservations(e.getValue())
+                        .build())
+                .sorted(Comparator.comparing(ReservationMonthlyTrendDto::getYearMonth))
+                .toList();
+    }
+
+    public Page<AdminReservationStatsListDto> getEventsByCategory(LocalDate startDate, LocalDate endDate, String mainCategory, String subCategory, Pageable pageable) {
+        if (mainCategory != null && "all".equalsIgnoreCase(mainCategory)) {
+            mainCategory = "";
+        }
+        if (subCategory != null && "all".equalsIgnoreCase(subCategory)) {
+            subCategory = "";
+        }
+        return dailyStatsCustomRepository.aggregatedPopularity(startDate, endDate, mainCategory, subCategory, pageable);
+    }
+
+    /**
+     * 검색 기능
+     */
+    public List<AdminReservationStatsListDto> searchEvents(LocalDate startDate, LocalDate endDate, String keyword, String mainCategory, String subCategory) {
+        if (mainCategory != null && "all".equalsIgnoreCase(mainCategory)) {
+            mainCategory = "";
+        }
+        if (subCategory != null && "all".equalsIgnoreCase(subCategory)) {
+            subCategory = "";
+        }
+        if (keyword == null || keyword.isBlank()) {
+            throw new IllegalArgumentException("검색어(keyword)는 null 또는 빈 문자열일 수 없습니다.");
+        }
+        return dailyStatsCustomRepository.searchEventReservationWithRank(startDate,  endDate,  keyword, mainCategory,  subCategory);
+    }
+}

--- a/src/main/java/com/fairing/fairplay/statistics/service/reservation/AdminReservationService.java
+++ b/src/main/java/com/fairing/fairplay/statistics/service/reservation/AdminReservationService.java
@@ -118,7 +118,7 @@ public class AdminReservationService {
     /**
      * 검색 기능
      */
-    public List<AdminReservationStatsListDto> searchEvents(LocalDate startDate, LocalDate endDate, String keyword, String mainCategory, String subCategory) {
+    public Page<AdminReservationStatsListDto> searchEvents(LocalDate startDate, LocalDate endDate, String keyword, String mainCategory, String subCategory, Pageable pageable ) {
         if (mainCategory != null && "all".equalsIgnoreCase(mainCategory)) {
             mainCategory = "";
         }
@@ -128,6 +128,6 @@ public class AdminReservationService {
         if (keyword == null || keyword.isBlank()) {
             throw new IllegalArgumentException("검색어(keyword)는 null 또는 빈 문자열일 수 없습니다.");
         }
-        return dailyStatsCustomRepository.searchEventReservationWithRank(startDate,  endDate,  keyword, mainCategory,  subCategory);
+        return dailyStatsCustomRepository.searchEventReservationWithRank(startDate,  endDate,  keyword, mainCategory,  subCategory, pageable);
     }
 }

--- a/src/main/java/com/fairing/fairplay/statistics/service/reservation/AdminReservationService.java
+++ b/src/main/java/com/fairing/fairplay/statistics/service/reservation/AdminReservationService.java
@@ -106,6 +106,11 @@ public class AdminReservationService {
     }
 
     public Page<AdminReservationStatsListDto> getEventsByCategory(LocalDate startDate, LocalDate endDate, String mainCategory, String subCategory, Pageable pageable) {
+
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("시작일이 종료일보다 늦을 수 없습니다.");
+            }
+
         if (mainCategory != null && "all".equalsIgnoreCase(mainCategory)) {
             mainCategory = "";
         }
@@ -119,6 +124,11 @@ public class AdminReservationService {
      * 검색 기능
      */
     public Page<AdminReservationStatsListDto> searchEvents(LocalDate startDate, LocalDate endDate, String keyword, String mainCategory, String subCategory, Pageable pageable ) {
+
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("시작일이 종료일보다 늦을 수 없습니다.");
+        }
+
         if (mainCategory != null && "all".equalsIgnoreCase(mainCategory)) {
             mainCategory = "";
         }

--- a/src/main/java/com/fairing/fairplay/statistics/service/reservation/StatisticsService.java
+++ b/src/main/java/com/fairing/fairplay/statistics/service/reservation/StatisticsService.java
@@ -2,6 +2,7 @@ package com.fairing.fairplay.statistics.service.reservation;
 
 import com.fairing.fairplay.statistics.dto.reservation.*;
 import com.fairing.fairplay.statistics.entity.reservation.EventDailyStatistics;
+import com.fairing.fairplay.statistics.repository.dailystats.DailyStatsCustomRepository;
 import com.fairing.fairplay.statistics.repository.dailystats.EventDailyStatisticsRepository;
 import com.fairing.fairplay.statistics.repository.hourlystats.EventHourlyStatisticsRepository;
 import com.fairing.fairplay.statistics.repository.sessionstats.EventSessionStatisticsRepository;
@@ -22,12 +23,12 @@ public class StatisticsService {
     private final EventHourlyStatisticsRepository hourlyRepo;
     private final EventTicketStatisticsRepository ticketRepo;
     private final EventSessionStatisticsRepository sessionRepo;
-
+    private final DailyStatsCustomRepository dailyStatsCustomRepository;
     // 데이터 집계
     @Transactional
     public void runBatch(LocalDate date) {
         try {
-            dailyRepo.saveAll(dailyRepo.calculate(date));
+            dailyRepo.saveAll(dailyStatsCustomRepository.calculate(date));
             hourlyRepo.saveAll(hourlyRepo.calculate(date));
             ticketRepo.saveAll(ticketRepo.calculate(date));
             sessionRepo.saveAll(sessionRepo.calculate(date));


### PR DESCRIPTION
예약 순위별 행사 리스트 기능을 추가했습니다 
기간별 예약 추이를  추가 했습니다 
카테고리별 예약 분포를 추가했습니다 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 관리자용 예약 분석 API 추가: 기간·카테고리(대/소)별 인기 목록(페이지네이션 지원) 제공
  * 키워드 기반 이벤트 예약 검색 API 제공(기간·카테고리 필터 가능)
  * 일간 및 월간 예약 트렌드 조회 API 추가
  * 예약 요약 API 제공: 총예약·총매출·총취소·평균매출·카테고리별 분포 반환
  * ISO 형식 날짜 파라미터 지원으로 기간 필터링 및 날짜 처리가 정확해짐
<!-- end of auto-generated comment: release notes by coderabbit.ai -->