### PR TITLE
feat: 프론트 지도 표시 위한 위경도 추가

### DIFF
--- a/src/main/java/com/fairing/fairplay/event/dto/EventSummaryDto.java
+++ b/src/main/java/com/fairing/fairplay/event/dto/EventSummaryDto.java
@@ -3,6 +3,7 @@ package com.fairing.fairplay.event.dto;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.*;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 @Getter
@@ -17,6 +18,8 @@ public class EventSummaryDto {  // 메인페이지, 검색 등에서 표시될 �
     private Integer minPrice;                   // 최소 가격
     private String mainCategory;          // 메인 카테고리
     private String location;                    // 장소명
+    private BigDecimal latitude;                // 위도
+    private BigDecimal longitude;               // 경도
     private LocalDate startDate;                // 행사 시작일
     private LocalDate endDate;                  // 행사 종료일
     private String thumbnailUrl;                // 썸네일 URL
@@ -25,6 +28,7 @@ public class EventSummaryDto {  // 메인페이지, 검색 등에서 표시될 �
     @QueryProjection
     public EventSummaryDto(Long id, String eventCode, Boolean hidden, String title,
                            Integer minPrice, String mainCategory, String location,
+                           BigDecimal latitude, BigDecimal longitude,
                            LocalDate startDate, LocalDate endDate, String thumbnailUrl, String region) {
         this.id = id;
         this.eventCode = eventCode;
@@ -33,6 +37,8 @@ public class EventSummaryDto {  // 메인페이지, 검색 등에서 표시될 �
         this.minPrice = minPrice;
         this.mainCategory = mainCategory;
         this.location = location;
+        this.latitude = latitude;
+        this.longitude = longitude;
         this.startDate = startDate;
         this.endDate = endDate;
         this.thumbnailUrl = thumbnailUrl;

--- a/src/main/java/com/fairing/fairplay/event/repository/EventQueryRepositoryImpl.java
+++ b/src/main/java/com/fairing/fairplay/event/repository/EventQueryRepositoryImpl.java
@@ -39,6 +39,8 @@ public class EventQueryRepositoryImpl implements EventQueryRepository {
                         ticket.price.min(),  // null 허용 (티켓 없을 경우)
                         detail.mainCategory.groupName,
                         detail.location.placeName,
+                        detail.location.latitude,
+                        detail.location.longitude,
                         detail.startDate,
                         detail.endDate,
                         detail.thumbnailUrl,
@@ -128,6 +130,8 @@ public class EventQueryRepositoryImpl implements EventQueryRepository {
                         ticket.price.min(), // 최소 가격 (null 허용)
                         detail.mainCategory.groupName,
                         detail.location.placeName,
+                        detail.location.latitude,
+                        detail.location.longitude,
                         detail.startDate,
                         detail.endDate,
                         detail.thumbnailUrl,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 이벤트 요약에 위도/경도 정보가 추가되었습니다. 목록·카드·상세 화면에서 장소명과 함께 좌표를 활용할 수 있어 지도 보기, 길찾기, 주변 검색, 마커 표시, 위치 공유 등에 사용 가능합니다.
* 기타
  * 검색/필터링/그룹핑/페이지네이션 동작은 동일하게 유지됩니다. 기존 데이터 및 표시 방식과의 호환성에 영향이 없으며, 좌표가 없는 항목도 정상적으로 노출됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->