### PR TITLE
feat: 좋아요 반응 추가 및 삭제 기능 추가

### DIFF
--- a/src/main/java/com/fairing/fairplay/review/controller/ReviewController.java
+++ b/src/main/java/com/fairing/fairplay/review/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package com.fairing.fairplay.review.controller;
 
+import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.review.dto.ReviewDeleteResponseDto;
 import com.fairing.fairplay.review.dto.ReviewResponseDto;
 import com.fairing.fairplay.review.dto.ReviewSaveRequestDto;
@@ -7,6 +8,7 @@ import com.fairing.fairplay.review.dto.ReviewSaveResponseDto;
 import com.fairing.fairplay.review.dto.ReviewUpdateRequestDto;
 import com.fairing.fairplay.review.dto.ReviewUpdateResponseDto;
 import com.fairing.fairplay.review.service.ReviewService;
+import com.fairing.fairplay.user.entity.Users;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,6 +16,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -39,10 +42,10 @@ public class ReviewController {
   // 행사 상세 페이지 리뷰 조회
   // GET /events/{eventId}/reviews?page=0&size=10&sort=createdDate,desc
   @GetMapping("/{eventId}")
-  public ResponseEntity<Page<ReviewResponseDto>> getReviewForEvent(@PathVariable Long eventId,
+  public ResponseEntity<Page<ReviewResponseDto>> getReviewForEvent(@PathVariable Long eventId, @AuthenticationPrincipal CustomUserDetails userDetails,
       @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
     return ResponseEntity.status(HttpStatus.OK)
-        .body(reviewService.getReviewForEvent(eventId, pageable));
+        .body(reviewService.getReviewForEvent(userDetails,eventId, pageable));
   }
 
   // 마이페이지 리뷰 조회

--- a/src/main/java/com/fairing/fairplay/review/controller/ReviewReactionController.java
+++ b/src/main/java/com/fairing/fairplay/review/controller/ReviewReactionController.java
@@ -1,6 +1,14 @@
 package com.fairing.fairplay.review.controller;
 
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.review.dto.ReactionRequestDto;
+import com.fairing.fairplay.review.dto.ReactionResponseDto;
+import com.fairing.fairplay.review.service.ReviewReactionService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,8 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ReviewReactionController {
 
+  private final ReviewReactionService reviewReactionService;
+
   // 리액션 추가
-
-  // 리액션 삭제
-
+  @PostMapping
+  public ResponseEntity<ReactionResponseDto> toggleReaction(@AuthenticationPrincipal
+  CustomUserDetails customUserDetails, @RequestBody ReactionRequestDto dto) {
+    return ResponseEntity.ok(reviewReactionService.toggleReaction(customUserDetails, dto));
+  }
 }

--- a/src/main/java/com/fairing/fairplay/review/dto/ReactionRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/review/dto/ReactionRequestDto.java
@@ -1,0 +1,15 @@
+package com.fairing.fairplay.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReactionRequestDto {
+
+  private Long reviewId;
+}

--- a/src/main/java/com/fairing/fairplay/review/dto/ReactionResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/review/dto/ReactionResponseDto.java
@@ -1,0 +1,16 @@
+package com.fairing.fairplay.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReactionResponseDto {
+
+  private Long reviewId; // 리뷰
+  private Long count; // 좋아요 총 갯수
+}

--- a/src/main/java/com/fairing/fairplay/review/entity/Review.java
+++ b/src/main/java/com/fairing/fairplay/review/entity/Review.java
@@ -65,5 +65,6 @@ public class Review {
   private boolean visible = true;
 
   @OneToMany(mappedBy = "review", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @Builder.Default
   private List<ReviewReaction> reactions = new ArrayList<>();
 }

--- a/src/main/java/com/fairing/fairplay/review/entity/ReviewReaction.java
+++ b/src/main/java/com/fairing/fairplay/review/entity/ReviewReaction.java
@@ -9,6 +9,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,6 +17,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 @Table(name = "review_reaction")
 public class ReviewReaction {
 

--- a/src/main/java/com/fairing/fairplay/review/repository/ReviewReactionRepository.java
+++ b/src/main/java/com/fairing/fairplay/review/repository/ReviewReactionRepository.java
@@ -1,8 +1,11 @@
 package com.fairing.fairplay.review.repository;
 
+import com.fairing.fairplay.review.entity.Review;
 import com.fairing.fairplay.review.entity.ReviewReaction;
 import com.fairing.fairplay.review.entity.ReviewReactionId;
+import com.fairing.fairplay.user.entity.Users;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,4 +14,8 @@ public interface ReviewReactionRepository extends JpaRepository<ReviewReaction, 
 
   @Query("SELECT r.review.id, COUNT(r) FROM ReviewReaction r WHERE r.review.id IN :reviewIds GROUP BY r.review.id")
   List<Object[]> countReactionsByReviewIds(@Param("reviewIds") List<Long> reviewIds);
+
+  Optional<ReviewReaction> findByReviewAndUser(Review review, Users user);
+
+  long countByReview(Review review);
 }

--- a/src/main/java/com/fairing/fairplay/review/repository/ReviewRepository.java
+++ b/src/main/java/com/fairing/fairplay/review/repository/ReviewRepository.java
@@ -41,4 +41,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   Page<Review> findByUser(Users user, Pageable pageable);
 
   boolean existsByReservationAndUser(Reservation reservation, Users user);
+  boolean existsByIdAndUser(Long id, Users user);
 }

--- a/src/main/java/com/fairing/fairplay/review/service/ReviewReactionService.java
+++ b/src/main/java/com/fairing/fairplay/review/service/ReviewReactionService.java
@@ -1,47 +1,121 @@
 package com.fairing.fairplay.review.service;
 
 import com.fairing.fairplay.common.exception.CustomException;
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.review.dto.ReactionRequestDto;
+import com.fairing.fairplay.review.dto.ReactionResponseDto;
+import com.fairing.fairplay.review.entity.Review;
+import com.fairing.fairplay.review.entity.ReviewReaction;
 import com.fairing.fairplay.review.repository.ReviewReactionRepository;
+import com.fairing.fairplay.review.repository.ReviewRepository;
+import com.fairing.fairplay.user.entity.Users;
+import com.fairing.fairplay.user.repository.UserRepository;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ReviewReactionService {
 
   private final ReviewReactionRepository reviewReactionRepository;
+  private final ReviewRepository reviewRepository;
+  private final UserRepository userRepository;
 
-  // 리뷰별 좋아요 카운트
+  @Transactional
+  public ReactionResponseDto toggleReaction(CustomUserDetails customUserDetails,
+      ReactionRequestDto dto) {
+    Long userId = customUserDetails.getUserId();
+    // 사용자 조회
+    Users user = userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, "사용자가 조회되지 않습니다."));
+
+    // 리뷰 조회
+    Review review = reviewRepository.findById(dto.getReviewId()).orElseThrow(
+        () -> new CustomException(HttpStatus.NOT_FOUND, "리뷰가 조회되지 않습니다.")
+    );
+
+    // 본인이 작성한 리뷰에 좋아요 반응을 추가하려하는 경우
+    if (review.getUser().equals(user)) {
+      throw new CustomException(HttpStatus.FORBIDDEN, "본인이 작성한 리뷰에는 좋아요 반응을 할 수 없습니다.");
+    }
+
+    // 기존 반응 여부 확인 -> 있으면 review에 대한 좋아요 반응 한 상태이므로 삭제. 없으면 추가
+    Optional<ReviewReaction> existingReaction = reviewReactionRepository.findByReviewAndUser(review,
+        user);
+
+    return existingReaction.isPresent() ? deleteReaction(existingReaction.get(), review)
+        : saveReaction(review, user);
+  }
+
+  // 여러 리뷰 ID에 대한 "좋아요(리액션) 개수 한번에 조회
   public Map<Long, Long> findReactionCountsByReviewIds(List<Long> reviewIds) {
+    // 조회할 리뷰 ID 없으면 빈 Map 반환
     if (reviewIds.isEmpty()) {
       return Collections.emptyMap();
     }
 
+    // [리뷰ID, 좋아요수]
     List<Object[]> results = reviewReactionRepository.countReactionsByReviewIds(reviewIds);
 
     return results.stream()
         .collect(Collectors.toMap(
             r -> {
               try {
-                return ((Number) r[0]).longValue();
+                return ((Number) r[0]).longValue(); // 리뷰ID
               } catch (ClassCastException e) {
                 throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR,
-                    "리뷰 반응 카운트 조회 중 오류가 발생했습니다.");
+                    "리뷰 반응 카운트 조회 중 오류가 발생했습니다."); // 타입 변환 실패 시 발생
               }
             },
             r -> {
               try {
-                return ((Number) r[1]).longValue();
+                return ((Number) r[1]).longValue(); // 좋아요 갯수
               } catch (ClassCastException e) {
                 throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR,
                     "리뷰 반응 카운트 조회 중 오류가 발생했습니다.");
               }
             }
         ));
+  }
+
+  private ReactionResponseDto saveReaction(Review review, Users user) {
+    ReviewReaction reviewReaction = buildReviewReaction(review, user);
+    reviewReactionRepository.save(reviewReaction);
+    long count = reviewReactionRepository.countByReview(review);
+    return buildReactionResponse(
+        review,
+        count
+    );
+  }
+
+  private ReactionResponseDto deleteReaction(ReviewReaction reviewReaction, Review review) {
+    reviewReactionRepository.delete(reviewReaction);
+    long count = reviewReactionRepository.countByReview(review);
+
+    return buildReactionResponse(
+        review,
+        count
+    );
+  }
+
+  private ReviewReaction buildReviewReaction(Review review, Users user) {
+    return ReviewReaction.builder()
+        .review(review)
+        .user(user)
+        .build();
+  }
+
+  private ReactionResponseDto buildReactionResponse(Review review, Long count) {
+    return ReactionResponseDto.builder()
+        .reviewId(review.getId())
+        .count(count)
+        .build();
   }
 }

--- a/src/main/java/com/fairing/fairplay/review/service/ReviewService.java
+++ b/src/main/java/com/fairing/fairplay/review/service/ReviewService.java
@@ -108,7 +108,7 @@ public class ReviewService {
 
     return reviewPage.map(review -> {
       long reactionCount = reactionCountMap.getOrDefault(review.getId(), 0L);
-      boolean isMine = (review.getUser().getUserId().equals(loginUserId));
+      boolean isMine = (loginUserId != null) && loginUserId.equals(review.getUser().getUserId());
       return buildReviewResponse(review, reactionCount, isMine);
     });
   }

--- a/src/main/java/com/fairing/fairplay/review/service/ReviewService.java
+++ b/src/main/java/com/fairing/fairplay/review/service/ReviewService.java
@@ -1,6 +1,7 @@
 package com.fairing.fairplay.review.service;
 
 import com.fairing.fairplay.common.exception.CustomException;
+import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.event.entity.Event;
 import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.review.dto.EventDto;
@@ -85,25 +86,29 @@ public class ReviewService {
   }
 
   // 행사 상세 페이지 - 특정 행사 리뷰 조회. CustomUserDetails 추가 예정
-  public Page<ReviewResponseDto> getReviewForEvent(Long eventId, Pageable pageable) {
-    Long loginUserId = 3L;
-    Users user = null;
-    if (loginUserId != null) {
-      user = findUserOrThrow(loginUserId);
+  public Page<ReviewResponseDto> getReviewForEvent(CustomUserDetails userDetails, Long eventId, Pageable pageable) {
+    Long loginUserId;
+    if (userDetails != null) {
+      loginUserId = userDetails.getUserId();
+    } else {
+      loginUserId = null;
     }
 
+    // 특정 이벤트 리뷰 조회
     Page<Review> reviewPage = reviewRepository.findByEventId(eventId, pageable);
 
+    // 리뷰 ID 추출
     List<Long> reviewIds = reviewPage.stream()
         .map(Review::getId)
         .toList();
 
+    // 이벤트의 리뷰들에 대한 카운트
     Map<Long, Long> reactionCountMap = reviewReactionService.findReactionCountsByReviewIds(
         reviewIds);
 
     return reviewPage.map(review -> {
       long reactionCount = reactionCountMap.getOrDefault(review.getId(), 0L);
-      boolean isMine = (loginUserId != null && review.getUser().getUserId().equals(loginUserId));
+      boolean isMine = (review.getUser().getUserId().equals(loginUserId));
       return buildReviewResponse(review, reactionCount, isMine);
     });
   }


### PR DESCRIPTION
## 변경 사항
- 좋아요 반응 토글 방식으로 추가/삭제 가능
   - 한 번 터치하면 반응 추가
   - 두 번 터치하면 반응 삭제
- 본인 리뷰에는 좋아요 반응 추가하지 못함

## 추가 사항
- API 테스트 진행 예정

## 관련 이슈
#37 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 리뷰에 대해 좋아요/취소를 토글할 수 있는 API가 추가되었습니다. 로그인한 사용자만 이용 가능하며 본인 리뷰에는 좋아요를 누를 수 없습니다.
  - 좋아요 처리 직후 해당 리뷰의 최신 좋아요 수를 반환합니다.
  - 이벤트 리뷰 목록에 사용자 컨텍스트가 반영되어 ‘내 리뷰’ 여부를 정확히 표시하고, 각 리뷰에 좋아요 수가 함께 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->