### PR TITLE
feat: 폼 링크 조회 및 응답 DTO 생성

### DIFF
--- a/src/main/java/com/fairing/fairplay/shareticket/controller/ShareTicketController.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/controller/ShareTicketController.java
@@ -1,0 +1,40 @@
+package com.fairing.fairplay.shareticket.controller;
+
+import com.fairing.fairplay.shareticket.dto.ShareTicketInfoResponseDto;
+import com.fairing.fairplay.shareticket.dto.ShareTicketSaveRequestDto;
+import com.fairing.fairplay.shareticket.service.ShareTicketService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+// 테스트용
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/form")
+public class ShareTicketController {
+  private final ShareTicketService shareTicketService;
+
+  // 공유폼생성
+//  @PostMapping
+//  public ResponseEntity<String> generateToken(@RequestBody ShareTicketSaveRequestDto dto) {
+//    log.info("Generating token for share ticket:{}",dto.getTotalAllowed());
+//    return ResponseEntity.ok(shareTicketService.generateToken(dto));
+//  }
+
+  // 공유폼조회
+  // 폼링크 조회 시 기본 정보 세팅
+  @GetMapping()
+  public ResponseEntity<ShareTicketInfoResponseDto> getFormInfo(@RequestParam String token){
+    return ResponseEntity.status(HttpStatus.OK).body(shareTicketService.getFormInfo(token));
+  }
+
+  //자동저장
+}

--- a/src/main/java/com/fairing/fairplay/shareticket/dto/ShareTicketInfoResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/dto/ShareTicketInfoResponseDto.java
@@ -1,0 +1,17 @@
+package com.fairing.fairplay.shareticket.dto;
+
+import com.fairing.fairplay.shareticket.entity.ShareTicket;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShareTicketInfoResponseDto {
+  private Long formId;
+  private Long eventId;
+  private String eventName;
+}

--- a/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketService.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketService.java
@@ -2,11 +2,17 @@ package com.fairing.fairplay.shareticket.service;
 
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.common.exception.LinkExpiredException;
-import com.fairing.fairplay.payment.entity.Payment;
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.event.repository.EventRepository;
+
 
 import com.fairing.fairplay.payment.repository.PaymentRepository;
+import com.fairing.fairplay.qr.dto.QrTicketRequestDto;
+import com.fairing.fairplay.qr.util.CodeGenerator;
+import com.fairing.fairplay.qr.util.CodeValidator;
 import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.reservation.repository.ReservationRepository;
+import com.fairing.fairplay.shareticket.dto.ShareTicketInfoResponseDto;
 import com.fairing.fairplay.shareticket.dto.ShareTicketSaveRequestDto;
 import com.fairing.fairplay.shareticket.entity.ShareTicket;
 import com.fairing.fairplay.shareticket.repository.ShareTicketRepository;
@@ -19,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +38,8 @@ public class ShareTicketService {
 
   private static final String RESERVATION = "RESERVATION";
   private static final String COMPLETED = "COMPLETED";
+  private final CodeValidator codeValidator;
+  private final EventRepository eventRepository;
 
   // 공유 폼 링크 생성 -> 예약 성공 시 예약 서비스 단계에서 사용
   @Transactional
@@ -84,6 +93,23 @@ public class ShareTicketService {
 
     shareTicketRepository.save(shareTicket);
     return token;
+  }
+
+  public ShareTicketInfoResponseDto getFormInfo(@RequestParam String token) {
+    ShareTicket shareTicket = shareTicketRepository.findByLinkToken(token).orElseThrow(
+        () -> new CustomException(HttpStatus.BAD_REQUEST,"잘못된 폼 링크입니다.")
+    );
+
+    QrTicketRequestDto dto = codeValidator.decodeToDto(token);
+    Event event = eventRepository.findById(dto.getEventId()).orElseThrow(
+        () -> new CustomException(HttpStatus.NOT_FOUND, "적절한 행사가 조회되지 않습니다.")
+    );
+
+    return ShareTicketInfoResponseDto.builder()
+        .formId(shareTicket.getId())
+        .eventId(event.getEventId())
+        .eventName(event.getTitleKr())
+        .build();
   }
 
   // 공유폼 token 유효성 검사


### PR DESCRIPTION
## 변경 사항
- 참석자 폼 링크 조회 API 생성

## 관련 이슈
#36 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 토큰을 사용해 폼 정보를 조회하는 공개 GET API를 추가했습니다 (/api/form?token=...).
  - 응답에 폼 ID, 이벤트 ID, 이벤트명을 제공하여 공유 링크만으로 핵심 정보를 확인할 수 있습니다.
  - 잘못된 링크이거나 존재하지 않는 이벤트인 경우 적절한 상태 코드로 안내합니다 (예: 400/404).
  - 모바일·웹 클라이언트에서 간단한 토큰 전달만으로 폼 진입 전 정보를 미리 확인하는 흐름을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->