### PR TITLE
feat: 개인정보 활용 동의 여부 추가 및 종료일 6개월 지난 행사와 연관된 참석자 정보 삭제

### DIFF
--- a/src/main/java/com/fairing/fairplay/attendee/controller/AttendeeController.java
+++ b/src/main/java/com/fairing/fairplay/attendee/controller/AttendeeController.java
@@ -41,7 +41,8 @@ public class AttendeeController {
   @GetMapping("/{reservationId}")
   public ResponseEntity<AttendeeListInfoResponseDto> findAll(@PathVariable Long reservationId,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
-    return ResponseEntity.status(HttpStatus.OK).body(attendeeService.findAll(reservationId, userDetails));
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(attendeeService.findAll(reservationId, userDetails));
   }
 
   // 참석자 정보 변경 -> 단체 예약일 경우에만 접근 가능

--- a/src/main/java/com/fairing/fairplay/attendee/dto/AttendeeInfoResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/attendee/dto/AttendeeInfoResponseDto.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-// 참석자 개별
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
@@ -17,4 +16,5 @@ public class AttendeeInfoResponseDto {
   private String name;
   private String email;
   private String phone;
+  private Boolean agreeToTerms;
 }

--- a/src/main/java/com/fairing/fairplay/attendee/dto/AttendeeSaveRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/attendee/dto/AttendeeSaveRequestDto.java
@@ -1,6 +1,5 @@
 package com.fairing.fairplay.attendee.dto;
 
-import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,5 +14,5 @@ public class AttendeeSaveRequestDto {
   private String name;
   private String email;
   private String phone;
-  private LocalDate birth;
+  private Boolean agreeToTerms;
 }

--- a/src/main/java/com/fairing/fairplay/attendee/entity/Attendee.java
+++ b/src/main/java/com/fairing/fairplay/attendee/entity/Attendee.java
@@ -19,8 +19,6 @@ import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.ColumnDefault;
 
-/*참석자*/
-/*추후 reservation 폴더로 이동될 가능성 있음*/
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
@@ -43,17 +41,27 @@ public class Attendee {
 
   @Column(name = "phone", nullable = true)
   private String phone;
+
   @Column(name = "email", nullable = true, unique = true)
   private String email;
+
   @Column(name = "birth", nullable = true)
   private LocalDate birth;
+
   @Column(name = "checked_in", nullable = false)
   @ColumnDefault("false")
   @Builder.Default
   private Boolean checkedIn = false;
+
+  @Column(name = "agree_to_terms", nullable = false)
+  @ColumnDefault("false")
+  @Builder.Default
+  private Boolean agreeToTerms = false;
+
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "attendee_type_code_id")
   private AttendeeTypeCode attendeeTypeCode;
+
   @CreationTimestamp
   @Column(name = "created_at", updatable = false)
   private LocalDateTime createdAt;

--- a/src/main/java/com/fairing/fairplay/attendee/repository/AttendeeRepository.java
+++ b/src/main/java/com/fairing/fairplay/attendee/repository/AttendeeRepository.java
@@ -1,6 +1,7 @@
 package com.fairing.fairplay.attendee.repository;
 
 import com.fairing.fairplay.attendee.entity.Attendee;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/fairing/fairplay/attendee/repository/AttendeeRepositoryCustom.java
+++ b/src/main/java/com/fairing/fairplay/attendee/repository/AttendeeRepositoryCustom.java
@@ -1,0 +1,34 @@
+package com.fairing.fairplay.attendee.repository;
+
+import com.fairing.fairplay.attendee.entity.QAttendee;
+import com.fairing.fairplay.event.entity.QEvent;
+import com.fairing.fairplay.event.entity.QEventDetail;
+import com.fairing.fairplay.reservation.entity.QReservation;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AttendeeRepositoryCustom {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  public void deleteAttendeesByEventEndDate() {
+    QAttendee attendee = QAttendee.attendee;
+    QReservation reservation = QReservation.reservation;
+    QEvent event = QEvent.event;
+    QEventDetail eventDetail = QEventDetail.eventDetail;
+
+    LocalDateTime sixMonthsAgo = LocalDateTime.now().minusMonths(6);
+
+    long deletedCount = jpaQueryFactory
+        .delete(attendee)
+        .where(attendee.reservation.event.eventDetail.endDate.before(LocalDate.from(sixMonthsAgo)))
+        .execute();
+
+    System.out.println("[Attendee Cleanup] 삭제된 참석자 수: " + deletedCount);
+  }
+}

--- a/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
+++ b/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
@@ -38,6 +38,9 @@ public class AttendeeService {
   // 대표자 정보 저장
   @Transactional
   public AttendeeInfoResponseDto savePrimary(AttendeeSaveRequestDto dto, Long reservationId) {
+    if(dto.getAgreeToTerms() == null || !dto.getAgreeToTerms()){
+      throw new CustomException(HttpStatus.BAD_REQUEST,"약관에 대해 동의하지 않았으므로 참석자 등록을 할 수 없습니다.");
+    }
     return saveAttendee("PRIMARY", dto, reservationId);
   }
 

--- a/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
+++ b/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
@@ -7,6 +7,7 @@ import com.fairing.fairplay.attendee.dto.AttendeeUpdateRequestDto;
 import com.fairing.fairplay.attendee.entity.Attendee;
 import com.fairing.fairplay.attendee.entity.AttendeeTypeCode;
 import com.fairing.fairplay.attendee.repository.AttendeeRepository;
+import com.fairing.fairplay.attendee.repository.AttendeeRepositoryCustom;
 import com.fairing.fairplay.attendee.repository.AttendeeTypeCodeRepository;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.security.CustomUserDetails;
@@ -14,6 +15,8 @@ import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.reservation.repository.ReservationRepository;
 import com.fairing.fairplay.shareticket.entity.ShareTicket;
 import com.fairing.fairplay.shareticket.service.ShareTicketService;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +31,7 @@ public class AttendeeService {
 
   private final AttendeeRepository attendeeRepository;
   private final AttendeeTypeCodeRepository attendeeTypeCodeRepository;
+  private final AttendeeRepositoryCustom attendeeRepositoryCustom;
   private final ShareTicketService shareTicketService;
   private final ReservationRepository reservationRepository;
 
@@ -129,6 +133,12 @@ public class AttendeeService {
     return attendees.stream()
         .map(this::buildAttendeeInfoResponse)
         .toList();
+  }
+
+  // 생성된 지 6개월 지난 참석자 정보 삭제
+  @Transactional
+  public void deleteOldAttendees(){
+    attendeeRepositoryCustom.deleteAttendeesByEventEndDate();
   }
 
   // DB save 로직 분리

--- a/src/main/java/com/fairing/fairplay/scheduler/AttendeeScheduler.java
+++ b/src/main/java/com/fairing/fairplay/scheduler/AttendeeScheduler.java
@@ -1,0 +1,17 @@
+package com.fairing.fairplay.scheduler;
+
+import com.fairing.fairplay.attendee.service.AttendeeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AttendeeScheduler {
+  private final AttendeeService attendeeService;
+
+//  @Scheduled(cron = "0 0 4 * * *")
+  public void deleteOldAttendees() {
+    attendeeService.deleteOldAttendees();
+  }
+}


### PR DESCRIPTION
## 변경 사항
- Attendee 엔티티에 개인정보 활용 동의 여부 속성 추가
- 6개월 지난 행사와 연관된 참석자 정보 삭제 스케쥴러 추가

## 추가 사항
- DB 변경 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 참석자 정보에 이용약관 동의(agreeToTerms) 항목 추가 — 저장 및 응답에 반영.
  * 행사 종료 후 6개월 지난 참석자 정리 기능 추가(정리 호출 API 및 스케줄러 클래스 추가, 스케줄링은 현재 비활성화).
* 버그 수정
  * 참석자 조회/수정 시 권한 검증 강화 및 오류 메시지 개선. 예매 대표자 외 수정 불가 검증 추가.
* 스타일
  * 컨트롤러 응답 구성의 포매팅 정리.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->