### PR TITLE
  feat: MyPage 예약/결제, 내티켓 관련 API에 결제 정보 연동 추가

### DIFF
--- a/src/main/java/com/fairing/fairplay/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/fairing/fairplay/payment/repository/PaymentRepository.java
@@ -20,4 +20,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     // imp_uid 중복 검증용
     boolean existsByImpUidAndPaymentStatusCode_Code(String impUid, String paymentStatusCode);
+    
+    // 특정 target_id와 payment_target_type으로 결제 정보 조회
+    Optional<Payment> findByTargetIdAndPaymentTargetType_PaymentTargetCode(Long targetId, String paymentTargetCode);
 }

--- a/src/main/java/com/fairing/fairplay/reservation/controller/MyReservationController.java
+++ b/src/main/java/com/fairing/fairplay/reservation/controller/MyReservationController.java
@@ -1,6 +1,8 @@
 package com.fairing.fairplay.reservation.controller;
 
 import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.payment.entity.Payment;
+import com.fairing.fairplay.payment.repository.PaymentRepository;
 import com.fairing.fairplay.reservation.dto.ReservationResponseDto;
 import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.reservation.service.ReservationService;
@@ -19,15 +21,34 @@ import java.util.List;
 public class MyReservationController {
 
     private final ReservationService reservationService;
+    private final PaymentRepository paymentRepository;
 
     @GetMapping
     public ResponseEntity<List<ReservationResponseDto>> getMyReservations(@AuthenticationPrincipal CustomUserDetails userDetails) {
 
         Long userId = userDetails.getUserId();
-        List<Reservation> myReservations =  reservationService.getMyReservations(userId);
+        List<Reservation> myReservations = reservationService.getMyReservations(userId);
 
         List<ReservationResponseDto> response = myReservations.stream()
-                .map(ReservationResponseDto::from)
+                .map(reservation -> {
+                    ReservationResponseDto dto = ReservationResponseDto.from(reservation);
+                    
+                    // 해당 예약과 연결된 결제 정보 조회
+                    Payment payment = paymentRepository.findByTargetIdAndPaymentTargetType_PaymentTargetCode(
+                            reservation.getReservationId(), "RESERVATION").orElse(null);
+                    
+                    if (payment != null) {
+                        dto.setPaymentId(payment.getPaymentId());
+                        dto.setMerchantUid(payment.getMerchantUid());
+                        dto.setImpUid(payment.getImpUid());
+                        dto.setPaymentAmount(payment.getAmount());
+                        dto.setPaymentStatus(payment.getPaymentStatusCode().getName());
+                        dto.setPaymentMethod(payment.getPaymentTypeCode().getName());
+                        dto.setPaidAt(payment.getPaidAt());
+                    }
+                    
+                    return dto;
+                })
                 .toList();
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/fairing/fairplay/reservation/dto/ReservationResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/reservation/dto/ReservationResponseDto.java
@@ -23,6 +23,7 @@ public class ReservationResponseDto {
     private Long eventId;
     private String eventName;
     private String eventDescription;
+    private String eventThumbnailUrl;
     
     // 회차 정보 (일정)
     private Long scheduleId;
@@ -56,6 +57,7 @@ public class ReservationResponseDto {
     private String impUid;
     private BigDecimal paymentAmount;
     private String paymentStatus;
+    private String paymentMethod;
     private LocalDateTime paidAt;
 
     public static ReservationResponseDto from(Reservation reservation) {
@@ -67,6 +69,11 @@ public class ReservationResponseDto {
         dto.eventId = reservation.getEvent().getEventId();
         dto.eventName = reservation.getEvent().getTitleKr();
         dto.eventDescription = reservation.getEvent().getTitleEng();
+        
+        // 이벤트 썸네일 URL (EventDetail에서 가져오기)
+        if (reservation.getEvent().getEventDetail() != null) {
+            dto.eventThumbnailUrl = reservation.getEvent().getEventDetail().getThumbnailUrl();
+        }
         
         // 일정 정보
         if (reservation.getSchedule() != null) {


### PR DESCRIPTION
  - PaymentRepository에 target_id와 결제 대상 타입으로 결제 정보 조회 메서드 추가
  - MyReservationController에서 예약 조회 시 결제 정보도 함께 조회하여 응답에 포함
  - ReservationResponseDto에 이벤트 썸네일 URL과 결제 수단 필드 추가
  - 예약 목록에서 결제 상태, 결제 수단, 이벤트 썸네일 정보 제공

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 내 예약 목록에서 각 예약의 결제 정보가 함께 표시됩니다: 결제 ID, 가맹점 주문번호, 결제사 거래번호, 결제금액, 결제상태, 결제수단, 결제일시.
  - 예약 항목에 이벤트 썸네일 이미지 URL이 추가로 노출됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->