### PR TITLE
feat: (행사담당자) 예약자 명단 조회 및 엑셀 다운로드 연결

### DIFF
--- a/src/main/java/com/fairing/fairplay/reservation/controller/ReservationController.java
+++ b/src/main/java/com/fairing/fairplay/reservation/controller/ReservationController.java
@@ -10,6 +10,9 @@ import com.fairing.fairplay.reservation.dto.ReservationResponseDto;
 import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.reservation.service.ReservationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -95,14 +98,19 @@ public class ReservationController {
         return ResponseEntity.ok(response);
     }
 
-    // 예약자 명단 조회 (행사 관리자용)
+    // 예약자 명단 조회 (행사 관리자용) - 페이지네이션 지원
     @GetMapping("/attendees")
     @FunctionAuth("getReservationAttendees")
-    public ResponseEntity<List<ReservationAttendeeDto>> getReservationAttendees(@PathVariable Long eventId,
+    public ResponseEntity<Page<ReservationAttendeeDto>> getReservationAttendees(
+            @PathVariable Long eventId,
             @RequestParam(required = false) String status,
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) String phone,
+            @RequestParam(required = false) Long reservationId,
+            @PageableDefault(size = 15, sort = "createdAt") Pageable pageable,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        // TODO: 행사 관리자 권한 확인 로직 추가 필요
-        List<ReservationAttendeeDto> attendees = reservationService.getReservationAttendees(eventId, status);
+        Page<ReservationAttendeeDto> attendees = reservationService.getReservationAttendees(
+                eventId, status, name, phone, reservationId, pageable);
         return ResponseEntity.ok(attendees);
     }
 
@@ -112,7 +120,6 @@ public class ReservationController {
     public ResponseEntity<byte[]> downloadAttendeesExcel(@PathVariable Long eventId,
             @RequestParam(required = false) String status,
             @AuthenticationPrincipal CustomUserDetails userDetails) throws IOException {
-        // TODO: 행사 관리자 권한 확인 로직 추가 필요
         byte[] excelData = reservationService.generateAttendeesExcel(eventId, status);
 
         String filename = "event_" + eventId + "_attendees.xlsx";

--- a/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepository.java
@@ -54,4 +54,27 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
       """)
   Page<PossibleReviewResponseDto> findPossibleReviewReservationsDto(@Param("userId") Long userId,
       Pageable pageable);
+
+  // 예약자 명단 조회 (페이지네이션 + 필터링)
+  @Query(value = """
+      SELECT r FROM Reservation r
+      JOIN FETCH r.user u
+      JOIN FETCH r.event e
+      LEFT JOIN FETCH r.schedule s
+      LEFT JOIN FETCH r.ticket t
+      LEFT JOIN FETCH r.reservationStatusCode rsc
+      WHERE r.event.eventId = :eventId
+      AND (:status IS NULL OR rsc.code = :status)
+      AND (:name IS NULL OR LOWER(u.name) LIKE LOWER(CONCAT('%', :name, '%')))
+      AND (:phone IS NULL OR u.phone LIKE CONCAT('%', :phone, '%'))
+      AND (:reservationId IS NULL OR r.reservationId = :reservationId)
+      ORDER BY r.createdAt DESC
+      """)
+  Page<Reservation> findReservationsWithFilters(
+      @Param("eventId") Long eventId,
+      @Param("status") String status,
+      @Param("name") String name,
+      @Param("phone") String phone,
+      @Param("reservationId") Long reservationId,
+      Pageable pageable);
 }

--- a/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepository.java
@@ -56,20 +56,32 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
       Pageable pageable);
 
   // 예약자 명단 조회 (페이지네이션 + 필터링)
-  @Query(value = """
-      SELECT r FROM Reservation r
-      JOIN FETCH r.user u
-      JOIN FETCH r.event e
-      LEFT JOIN FETCH r.schedule s
-      LEFT JOIN FETCH r.ticket t
-      LEFT JOIN FETCH r.reservationStatusCode rsc
-      WHERE r.event.eventId = :eventId
-      AND (:status IS NULL OR rsc.code = :status)
-      AND (:name IS NULL OR LOWER(u.name) LIKE LOWER(CONCAT('%', :name, '%')))
-      AND (:phone IS NULL OR u.phone LIKE CONCAT('%', :phone, '%'))
-      AND (:reservationId IS NULL OR r.reservationId = :reservationId)
-      ORDER BY r.createdAt DESC
-      """)
+  @Query(
+          value = """
+        SELECT r FROM Reservation r
+        JOIN FETCH r.user u
+        JOIN FETCH r.event e
+        LEFT JOIN FETCH r.schedule s
+        LEFT JOIN FETCH r.ticket t
+        LEFT JOIN FETCH r.reservationStatusCode rsc
+        WHERE r.event.eventId = :eventId
+          AND (:status IS NULL OR rsc.code = :status)
+          AND (:name IS NULL OR LOWER(u.name) LIKE LOWER(CONCAT('%', :name, '%')))
+          AND (:phone IS NULL OR u.phone LIKE CONCAT('%', :phone, '%'))
+          AND (:reservationId IS NULL OR r.reservationId = :reservationId)
+        ORDER BY r.createdAt DESC
+    """,
+          countQuery = """
+        SELECT COUNT(r) FROM Reservation r
+        LEFT JOIN r.user u
+        LEFT JOIN r.reservationStatusCode rsc
+        WHERE r.event.eventId = :eventId
+          AND (:status IS NULL OR rsc.code = :status)
+          AND (:name IS NULL OR LOWER(u.name) LIKE LOWER(CONCAT('%', :name, '%')))
+          AND (:phone IS NULL OR u.phone LIKE CONCAT('%', :phone, '%'))
+          AND (:reservationId IS NULL OR r.reservationId = :reservationId)
+    """
+  )
   Page<Reservation> findReservationsWithFilters(
       @Param("eventId") Long eventId,
       @Param("status") String status,

--- a/src/main/java/com/fairing/fairplay/reservation/service/ReservationService.java
+++ b/src/main/java/com/fairing/fairplay/reservation/service/ReservationService.java
@@ -26,6 +26,9 @@ import com.fairing.fairplay.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -372,7 +375,20 @@ public class ReservationService {
         return reservationRepository.findByUser_userId(userId);
     }
 
-    // 예약자 명단 조회 (행사 관리자용)
+    // 예약자 명단 조회 (행사 관리자용) - 페이지네이션 지원
+    @Transactional(readOnly = true)
+    public Page<ReservationAttendeeDto> getReservationAttendees(
+            Long eventId, String status, String name, String phone, Long reservationId, Pageable pageable) {
+        
+        // Repository에서 페이지네이션과 필터링을 지원하는 메서드 호출
+        Page<Reservation> reservationPage = reservationRepository.findReservationsWithFilters(
+                eventId, status, name, phone, reservationId, pageable);
+        
+        // Reservation을 ReservationAttendeeDto로 변환
+        return reservationPage.map(ReservationAttendeeDto::from);
+    }
+
+    // 기존 메서드 유지 (엑셀 다운로드용)
     @Transactional(readOnly = true)
     public List<ReservationAttendeeDto> getReservationAttendees(Long eventId, String status) {
         List<Reservation> reservations;


### PR DESCRIPTION
- 페이징 처리 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 참가자 조회에 페이지네이션 도입: 기본 15개, 생성일(createdAt) 기준 내림차순 정렬 적용.
  - 추가 필터 제공: 이름, 전화번호, 예약번호를 상태 필터와 함께 조합 가능.
- 문서
  - API 엔드포인트 문서에 페이지네이션 및 새로운 필터 옵션 반영.
- 기타
  - 엑셀 다운로드는 기존과 동일한 비페이징 방식 유지.
  - 사소한 주석 정리(기능적 변경 없음).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->