### PR TITLE
feat: banner: hot, md_pick, new

### DIFF
--- a/src/main/java/com/fairing/fairplay/banner/batch/BannerExpirationScheduler.java
+++ b/src/main/java/com/fairing/fairplay/banner/batch/BannerExpirationScheduler.java
@@ -1,0 +1,34 @@
+package com.fairing.fairplay.banner.batch;
+
+import com.fairing.fairplay.banner.repository.BannerRepository;
+import com.fairing.fairplay.banner.repository.BannerStatusCodeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BannerExpirationScheduler {
+
+    private final BannerRepository bannerRepository;
+    private final BannerStatusCodeRepository statusRepo;
+
+    // 매일 새벽 1시
+    @Scheduled(cron = "0 1 1 * * *")
+    @Transactional
+    public void deactivateExpiredBanners() {
+        var inactive = statusRepo.findByCode("INACTIVE")
+                .orElseThrow(() -> new IllegalStateException("INACTIVE 상태 코드 없음"));
+        int updated = bannerRepository.deactivateExpiredAll(LocalDateTime.now(), inactive); // 전체 타입 만료 처리
+        if (updated > 0) {
+            log.info("만료된 배너 {}건을 INACTIVE로 변경", updated);
+        } else {
+            log.debug("만료된 HERO/SEARCH_TOP 배너 없음");
+        }
+    }
+}

--- a/src/main/java/com/fairing/fairplay/banner/batch/HotPickScheduler.java
+++ b/src/main/java/com/fairing/fairplay/banner/batch/HotPickScheduler.java
@@ -1,0 +1,92 @@
+package com.fairing.fairplay.banner.batch;
+
+import com.fairing.fairplay.banner.entity.Banner;
+import com.fairing.fairplay.banner.entity.BannerStatusCode;
+import com.fairing.fairplay.banner.entity.BannerType;
+import com.fairing.fairplay.banner.repository.BannerRepository;
+import com.fairing.fairplay.banner.repository.BannerStatusCodeRepository;
+import com.fairing.fairplay.banner.repository.BannerTypeRepository;
+import com.fairing.fairplay.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HotPickScheduler {
+
+    private final BannerRepository bannerRepository;
+    private final BannerStatusCodeRepository statusRepo;
+    private final BannerTypeRepository typeRepo;
+    private final ReservationRepository reservationRepository;
+
+    private static final int HOT_PICK_LIMIT = 5; // 상위 N개
+
+    @Scheduled(cron = "0 0 2 * * *") // 매일 새벽 2시
+    @Transactional
+    public void updateHotPicks() {
+        BannerType hotPickType = typeRepo.findByCode("HOT_PICK")
+                .orElseThrow(() -> new IllegalStateException("HOT_PICK 배너 타입 없음"));
+        BannerStatusCode active = statusRepo.findByCode("ACTIVE")
+                .orElseThrow(() -> new IllegalStateException("ACTIVE 상태 코드 없음"));
+        BannerStatusCode inactive = statusRepo.findByCode("INACTIVE")
+                .orElseThrow(() -> new IllegalStateException("INACTIVE 상태 코드 없음"));
+
+        // 기존 HOT_PICK 모두 비활성화
+        bannerRepository.deactivateAllActiveByType(hotPickType.getCode(), "ACTIVE", inactive);
+
+
+// 예매 수량 상위 이벤트 조회 (CONFIRMED 만 포함)
+        List<Object[]> ranking = reservationRepository
+                .findEventBookingQuantities(java.util.List.of("CONFIRMED"));
+
+        // 예매율 순위 조회
+        List<Object[]> bookingRates = reservationRepository.findEventBookingRates("CONFIRMED");
+
+        int prio = 0;
+        int created = 0;
+
+        LocalDateTime startAt = LocalDateTime.now().withSecond(0).withNano(0);
+        LocalDateTime endAt   = startAt.plusDays(7);
+
+        for (Object[] row : bookingRates) {
+            if (created >= HOT_PICK_LIMIT) break;
+            Long eventId = ((Number) row[0]).longValue();
+
+
+            // 같은 이벤트가 이미 HOT_PICK ACTIVE 상태면 건너뜀 (선택)
+            if (bannerRepository.existsByBannerType_CodeAndEventIdAndBannerStatusCode_Code(
+                    hotPickType.getCode(), eventId, active.getCode())) {
+                continue;
+            }
+
+
+                    Banner banner = new Banner(
+                            "Hot Pick" + eventId,
+                            "",  // image_url (TODO: 이벤트/파일에서 가져오기)
+                            null,
+                            prio++,             // <- 0,1,2… UK 충돌 방지
+                            startAt,
+                            endAt,
+                            active,
+                            hotPickType
+                    );
+                    banner.setEventId(eventId);
+                    bannerRepository.save(banner);
+            created++;
+
+                }
+
+
+        log.info("HOT_PICK 배너 {}건 생성 완료", created);
+
+
+ }
+}
+

--- a/src/main/java/com/fairing/fairplay/banner/batch/NewPickScheduler.java
+++ b/src/main/java/com/fairing/fairplay/banner/batch/NewPickScheduler.java
@@ -23,7 +23,7 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-@Profile("local")
+//@Profile("local")
 
 public class NewPickScheduler {
 

--- a/src/main/java/com/fairing/fairplay/banner/batch/NewPickScheduler.java
+++ b/src/main/java/com/fairing/fairplay/banner/batch/NewPickScheduler.java
@@ -1,0 +1,108 @@
+package com.fairing.fairplay.banner.batch;
+
+import com.fairing.fairplay.banner.entity.Banner;
+import com.fairing.fairplay.banner.entity.BannerStatusCode;
+import com.fairing.fairplay.banner.entity.BannerType;
+import com.fairing.fairplay.banner.repository.BannerRepository;
+import com.fairing.fairplay.banner.repository.BannerStatusCodeRepository;
+import com.fairing.fairplay.banner.repository.BannerTypeRepository;
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.event.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile("local")
+
+public class NewPickScheduler {
+
+    private final BannerRepository bannerRepository;
+    private final BannerStatusCodeRepository statusRepo;
+    private final BannerTypeRepository typeRepo;
+    private final EventRepository eventRepository;
+
+    @Value("${banner.new.limit:5}")
+    private int newLimit;
+
+    @Value("${banner.new.expose-days:7}")
+    private int exposeDays;
+
+    //@Scheduled(cron = "0 5 2 * * *")
+    //@Scheduled(cron = "0 */1 * * * *") // 임시: 1분마다
+
+    @Transactional
+    public void updateNewPicks() {
+        BannerType newType = typeRepo.findByCode("NEW")
+                .orElseThrow(() -> new IllegalStateException("NEW 배너 타입 없음"));
+        BannerStatusCode active = statusRepo.findByCode("ACTIVE")
+                .orElseThrow(() -> new IllegalStateException("ACTIVE 상태 코드 없음"));
+        BannerStatusCode inactive = statusRepo.findByCode("INACTIVE")
+                .orElseThrow(() -> new IllegalStateException("INACTIVE 상태 코드 없음"));
+
+        // 기존 NEW 중 ACTIVE만 비활성화 (히스토리 보존)
+        bannerRepository.deactivateAllActiveByType(newType.getCode(), "ACTIVE", inactive);
+
+        // 다른 타입과 중복 노출 제외 목록
+        List<Long> excludeIds = bannerRepository.findActiveEventIdsInTypes(
+                java.util.Arrays.asList("HERO","SEARCH_TOP","MD_PICK","HOT_PICK")
+        );
+
+        // 최신 이벤트 N개 (event_detail.created_at 기준) — 리포지토리 시그니처는 List 반환 그대로 사용
+        List<Event> latest =
+                eventRepository.findByEventDetailIsNotNullOrderByEventDetail_CreatedAtDesc(
+                        PageRequest.of(0, newLimit)
+                );
+
+        int prio = 0;
+        LocalDateTime startAt = LocalDateTime.now();
+        LocalDateTime endAt   = startAt.plusDays(exposeDays);
+        int created = 0;
+        for (Event ev : latest) {
+            if (created >= newLimit) break;
+
+            Long eventId = ev.getEventId();
+            if (excludeIds.contains(eventId)) continue; // 타 타입과 중복 방지
+
+            // 이미 NEW 타입으로 ACTIVE면 스킵
+            if (bannerRepository.existsByBannerType_CodeAndEventIdAndBannerStatusCode_Code(
+                    newType.getCode(), eventId, active.getCode())) {
+                continue;
+            }
+
+            String title = ev.getTitleKr();
+            if (title == null || title.isBlank()) title = ev.getTitleEng();
+
+            String thumb = null;
+            if (ev.getEventDetail() != null) {
+                thumb = ev.getEventDetail().getThumbnailUrl();
+            }
+
+            Banner b = new Banner(
+                    (title != null ? title : ("New Event " + eventId)),
+                    thumb,                 // null이면 프론트/엔티티에서 기본 이미지 처리
+                    null,
+                    prio++,
+                    startAt,          // ← 동일 시작
+                    endAt,
+                    active,
+                    newType
+            );
+            b.setEventId(eventId);
+            bannerRepository.save(b);
+            created++;
+        }
+
+        log.info("NEW 배너 {}건 생성 완료", created); //  실제 생성 건수 기준 로그
+    }
+}

--- a/src/main/java/com/fairing/fairplay/banner/controller/AdminBannerBatchController.java
+++ b/src/main/java/com/fairing/fairplay/banner/controller/AdminBannerBatchController.java
@@ -5,9 +5,11 @@ import com.fairing.fairplay.banner.batch.HotPickScheduler;
 import com.fairing.fairplay.banner.batch.NewPickScheduler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@PreAuthorize("hasRole('ADMIN')")
 @RequestMapping("/api/admin/batch")
 @RequiredArgsConstructor
 public class AdminBannerBatchController {

--- a/src/main/java/com/fairing/fairplay/banner/controller/AdminBannerBatchController.java
+++ b/src/main/java/com/fairing/fairplay/banner/controller/AdminBannerBatchController.java
@@ -1,0 +1,30 @@
+package com.fairing.fairplay.banner.controller;
+
+
+import com.fairing.fairplay.banner.batch.HotPickScheduler;
+import com.fairing.fairplay.banner.batch.NewPickScheduler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/batch")
+@RequiredArgsConstructor
+public class AdminBannerBatchController {
+
+    private final NewPickScheduler newPickScheduler;
+
+    @PostMapping("/new-picks/run")
+    public ResponseEntity<Void> runNewPicks() {
+        newPickScheduler.updateNewPicks();
+        return ResponseEntity.ok().build();
+    }
+
+    private final HotPickScheduler hotPickScheduler;
+
+    @PostMapping("/hot-picks/run")
+    public ResponseEntity<Void> runHotPicks() {
+        hotPickScheduler.updateHotPicks();
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/fairing/fairplay/banner/controller/AdminBannerBatchController.java
+++ b/src/main/java/com/fairing/fairplay/banner/controller/AdminBannerBatchController.java
@@ -9,7 +9,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@PreAuthorize("hasRole('ADMIN')")
 @RequestMapping("/api/admin/batch")
 @RequiredArgsConstructor
 public class AdminBannerBatchController {

--- a/src/main/java/com/fairing/fairplay/banner/entity/Banner.java
+++ b/src/main/java/com/fairing/fairplay/banner/entity/Banner.java
@@ -33,7 +33,7 @@ public class Banner {
     @Column(nullable = false, length = 100)
     private String title;
 
-    @Column(nullable = false, length = 255)
+    @Column(nullable = true, length = 255)
     private String imageUrl;
 
     @Column(length = 255)

--- a/src/main/java/com/fairing/fairplay/banner/repository/BannerRepository.java
+++ b/src/main/java/com/fairing/fairplay/banner/repository/BannerRepository.java
@@ -1,9 +1,10 @@
 package com.fairing.fairplay.banner.repository;
 
 import com.fairing.fairplay.banner.entity.Banner;
-import org.springframework.data.jpa.repository.JpaRepository;
+import com.fairing.fairplay.banner.entity.BannerStatusCode;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -11,14 +12,77 @@ import java.util.List;
 @Repository
 public interface BannerRepository extends JpaRepository<Banner, Long> {
 
-    // (1) 타입까지 지정해서 가져오기 (HERO, SEARCH_TOP 등)
+    // 노출 배너 조회 (타입 지정)
     List<Banner> findAllByBannerType_CodeAndBannerStatusCode_CodeAndStartDateLessThanEqualAndEndDateGreaterThanEqualOrderByPriorityAsc(
             String typeCode, String statusCode, LocalDateTime now1, LocalDateTime now2
     );
 
-    // (2) 타입 무시하고 전체 활성 배너 (필요하면 유지)
+    // 노출 배너 조회 (타입 무시)
     List<Banner> findAllByBannerStatusCode_CodeAndStartDateLessThanEqualAndEndDateGreaterThanEqualOrderByPriorityAsc(
             String code, LocalDateTime now1, LocalDateTime now2
     );
-}
 
+
+
+    // 기간 만료된 배너 전체 INACTIVE 처리 (ALL TYPES)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+      update Banner b
+         set b.bannerStatusCode = :inactiveStatus
+       where b.bannerStatusCode.code = 'ACTIVE'
+         and b.endDate < :now
+    """)
+    int deactivateExpiredAll(@Param("now") LocalDateTime now,
+                             @Param("inactiveStatus") BannerStatusCode inactiveStatus);
+
+    // 특정 타입 "전체" 비활성화 (필요 시 사용)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update Banner b
+           set b.bannerStatusCode = :inactiveStatus
+         where b.bannerType.code = :typeCode
+    """)
+    int deactivateAllByType(@Param("typeCode") String typeCode,
+                            @Param("inactiveStatus") BannerStatusCode inactiveStatus);
+
+    // 특정 타입의 ACTIVE만 전부 비활성화 (create 시 사용)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update Banner b
+           set b.bannerStatusCode = :inactiveStatus
+         where b.bannerType.code = :typeCode
+           and b.bannerStatusCode.code = :activeCode
+    """)
+    int deactivateAllActiveByType(@Param("typeCode") String typeCode,
+                                  @Param("activeCode") String activeCode,
+                                  @Param("inactiveStatus") BannerStatusCode inactiveStatus);
+
+    //  “하나만 유지”: 자기 자신 제외 ACTIVE 비활성화 (update/status-change 시 사용)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update Banner b
+           set b.bannerStatusCode = :inactiveStatus
+         where b.bannerType.code = :typeCode
+           and b.bannerStatusCode.code = :activeCode
+           and b.id <> :excludeId
+    """)
+    int deactivateOthersActiveByType(@Param("typeCode") String typeCode,
+                                     @Param("activeCode") String activeCode,
+                                     @Param("inactiveStatus") BannerStatusCode inactiveStatus,
+                                     @Param("excludeId") Long excludeId);
+
+
+    @Query("""
+    SELECT DISTINCT b.eventId
+      FROM Banner b
+     WHERE b.bannerStatusCode.code = 'ACTIVE'
+       AND b.bannerType.code IN :typeCodes
+       AND b.eventId IS NOT NULL
+""")
+    List<Long> findActiveEventIdsInTypes(@Param("typeCodes") List<String> typeCodes);
+
+    // 중복 방지 체크
+    boolean existsByBannerType_CodeAndEventIdAndBannerStatusCode_Code(
+            String typeCode, Long eventId, String statusCode
+    );
+}

--- a/src/main/java/com/fairing/fairplay/banner/service/BannerService.java
+++ b/src/main/java/com/fairing/fairplay/banner/service/BannerService.java
@@ -4,56 +4,64 @@ import com.fairing.fairplay.banner.dto.*;
 import com.fairing.fairplay.banner.entity.*;
 import com.fairing.fairplay.banner.repository.*;
 import com.fairing.fairplay.common.exception.CustomException;
-import com.fairing.fairplay.core.service.AwsS3Service;
 import com.fairing.fairplay.event.repository.EventRepository;
 import com.fairing.fairplay.file.dto.S3UploadRequestDto;
-import com.fairing.fairplay.file.entity.File;
+import com.fairing.fairplay.file.dto.S3UploadResponseDto;
 import com.fairing.fairplay.file.service.FileService;
 import com.fairing.fairplay.user.entity.Users;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class BannerService {
 
     private static final String STATUS_ACTIVE = "ACTIVE";
     private static final String ACTION_CREATE = "CREATE";
     private static final String ACTION_UPDATE = "UPDATE";
     private static final String ACTION_PRIORITY_CHANGE = "PRIORITY_CHANGE";
+    private static final String TYPE_MD_PICK = "MD_PICK";
+    private static final String STATUS_INACTIVE = "INACTIVE";
 
     private final BannerRepository bannerRepository;
     private final BannerStatusCodeRepository bannerStatusCodeRepository;
     private final BannerActionCodeRepository bannerActionCodeRepository;
     private final BannerLogRepository bannerLogRepository;
     private final FileService fileService;
-    private final AwsS3Service awsS3Service;
     private final BannerTypeRepository bannerTypeRepository;
     private final EventRepository eventRepository;
 
+    // S3 디렉토리명 설정(기본값 banner)
     @Value("${cloud.aws.s3.banner-dir:banner}")
     private String bannerDir;
 
+    // 등록
     @Transactional
     public BannerResponseDto createBanner(BannerRequestDto dto, Long adminId) {
         validateEvent(dto.getEventId());
+
+
+        if (dto.getStartDate() != null && dto.getEndDate() != null
+                && dto.getStartDate().isAfter(dto.getEndDate())) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "노출 기간이 올바르지 않습니다.", null);
+        }
+
+        // 통일된 이미지 처리(등록 전용: 반드시 이미지 필요)
+        String finalImageUrl = resolveImageUrlForCreate(dto);
 
         BannerStatusCode statusCode = getStatusCodeOr404(dto.getStatusCode());
         BannerType bannerType = getBannerTypeOr404(dto.getBannerTypeId());
 
         Banner banner = new Banner(
                 dto.getTitle(),
-                null, // 이미지 URL은 파일 처리 후 설정
+                finalImageUrl,
                 dto.getLinkUrl(),
                 dto.getPriority(),
                 dto.getStartDate(),
@@ -66,13 +74,16 @@ public class BannerService {
 
         Banner saved = bannerRepository.save(banner);
 
-        String finalImageUrl = resolveImageUrlForCreate(dto, saved.getId());
-        saved.setImageUrl(finalImageUrl);
+        if (TYPE_MD_PICK.equals(bannerType.getCode()) && STATUS_ACTIVE.equals(statusCode.getCode())) {
+            BannerStatusCode inactive = getStatusCodeOr404(STATUS_INACTIVE);
+            bannerRepository.deactivateOthersActiveByType(TYPE_MD_PICK, STATUS_ACTIVE, inactive, saved.getId());
+        }
 
         logBannerAction(saved, adminId, ACTION_CREATE);
         return toDto(saved);
     }
 
+    // 수정
     @Transactional
     public BannerResponseDto updateBanner(Long bannerId, BannerRequestDto dto, Long adminId) {
         Banner banner = getBannerOr404(bannerId);
@@ -86,7 +97,8 @@ public class BannerService {
             throw new CustomException(HttpStatus.BAD_REQUEST, "노출 기간이 올바르지 않습니다.", null);
         }
 
-        String finalImageUrl = resolveImageUrlForUpdate(dto, banner, adminId);
+        // 통일된 이미지 처리(수정 전용: 입력 없으면 기존 유지)
+        String finalImageUrl = resolveImageUrlForUpdate(dto, banner.getImageUrl());
 
         BannerStatusCode statusCode = getStatusCodeOr404(dto.getStatusCode());
         BannerType bannerType = getBannerTypeOr404(dto.getBannerTypeId());
@@ -102,16 +114,35 @@ public class BannerService {
         );
         banner.updateStatus(statusCode);
 
+// MD_PICK 하나만 유지: 결과가 MD_PICK + ACTIVE면 자기 자신 제외 모두 INACTIVE
+        if (TYPE_MD_PICK.equals(banner.getBannerType().getCode())
+                && STATUS_ACTIVE.equals(banner.getBannerStatusCode().getCode())) {
+            BannerStatusCode inactive = getStatusCodeOr404(STATUS_INACTIVE);
+            bannerRepository.deactivateOthersActiveByType(
+                    TYPE_MD_PICK, STATUS_ACTIVE, inactive, banner.getId()
+            );
+        }
+
         logBannerAction(banner, adminId, ACTION_UPDATE);
         return toDto(banner);
     }
 
+    // 상태 우선 순위
     @Transactional
     public void changeStatus(Long bannerId, BannerStatusUpdateDto dto, Long adminId) {
         Banner banner = getBannerOr404(bannerId);
         BannerStatusCode statusCode = getStatusCodeOr404(dto.getStatusCode());
         banner.updateStatus(statusCode);
         logBannerAction(banner, adminId, ACTION_UPDATE);
+
+        //  MD_PICK을 ACTIVE로 바꾸면, 자신 제외 모두 INACTIVE
+        if (TYPE_MD_PICK.equals(banner.getBannerType().getCode())
+                && STATUS_ACTIVE.equals(statusCode.getCode())) {
+            BannerStatusCode inactive = getStatusCodeOr404(STATUS_INACTIVE);
+            bannerRepository.deactivateOthersActiveByType(
+                    TYPE_MD_PICK, STATUS_ACTIVE, inactive, banner.getId()
+            );
+        }
     }
 
     @Transactional
@@ -121,6 +152,7 @@ public class BannerService {
         logBannerAction(banner, adminId, ACTION_PRIORITY_CHANGE);
     }
 
+    // 조회
     @Transactional(readOnly = true)
     public List<BannerResponseDto> getAllActiveBanners() {
         LocalDateTime now = LocalDateTime.now();
@@ -142,56 +174,47 @@ public class BannerService {
                 .collect(Collectors.toList());
     }
 
+    // 공통 핼퍼
+
     private void validateEvent(Long eventId) {
         if (eventId == null || !eventRepository.existsById(eventId)) {
             throw new CustomException(HttpStatus.NOT_FOUND, "해당 행사를 찾을 수 없습니다.", null);
         }
     }
 
-    private String resolveImageUrlForCreate(BannerRequestDto dto, Long bannerId) {
-        if (!StringUtils.hasText(dto.getS3Key()) && !StringUtils.hasText(dto.getImageUrl())) {
-            throw new CustomException(HttpStatus.BAD_REQUEST, "이미지 정보가 없습니다. s3Key 또는 imageUrl이 필요합니다.", null);
-        }
+    // 등록: s3Key 또는 imageUrl 반드시 필요(없으면 400)
+    private String resolveImageUrlForCreate(BannerRequestDto dto) {
         if (StringUtils.hasText(dto.getS3Key())) {
-            return uploadToS3(dto, bannerId);
-        }
-        return dto.getImageUrl();
-    }
-
-    private String resolveImageUrlForUpdate(BannerRequestDto dto, Banner banner, Long adminId) {
-        if (StringUtils.hasText(dto.getS3Key())) {
-            // 기존 파일이 있다면 삭제
-            if (StringUtils.hasText(banner.getImageUrl())) {
-                try {
-                    String s3Key = awsS3Service.getS3KeyFromPublicUrl(banner.getImageUrl());
-                    if (s3Key != null) {
-                        fileService.deleteFileByS3Key(s3Key);
-                    }
-                } catch (Exception e) {
-                    log.warn("기존 배너 이미지 S3 삭제 실패 - URL: {}, Error: {}", banner.getImageUrl(), e.getMessage());
-                }
-            }
-            return uploadToS3(dto, banner.getId());
+            return uploadToS3(dto);
         }
         if (StringUtils.hasText(dto.getImageUrl())) {
             return dto.getImageUrl();
         }
-        return banner.getImageUrl();
+        throw new CustomException(HttpStatus.BAD_REQUEST, "이미지 정보가 없습니다. s3Key 또는 imageUrl이 필요합니다.", null);
     }
 
-    private String uploadToS3(BannerRequestDto dto, Long bannerId) {
-        File savedFile = fileService.uploadFile(
+    // 수정: s3Key가 있으면 업로드, imageUrl이 있으면 교체, 둘 다 없으면 기존 유지
+    private String resolveImageUrlForUpdate(BannerRequestDto dto, String currentUrl) {
+        if (StringUtils.hasText(dto.getS3Key())) {
+            return uploadToS3(dto);
+        }
+        if (StringUtils.hasText(dto.getImageUrl())) {
+            return dto.getImageUrl();
+        }
+        return currentUrl;
+    }
+
+    private String uploadToS3(BannerRequestDto dto) {
+        S3UploadResponseDto uploadResult = fileService.uploadFile(
                 S3UploadRequestDto.builder()
                         .s3Key(dto.getS3Key())
                         .originalFileName(dto.getOriginalFileName())
                         .fileType(dto.getFileType())
                         .fileSize(dto.getFileSize())
                         .directoryPrefix(bannerDir)
-                        .usage("banner")
                         .build()
         );
-        fileService.createFileLink(savedFile, "BANNER", bannerId);
-        return awsS3Service.getCdnUrl(savedFile.getFileUrl());
+        return uploadResult.getFileUrl();
     }
 
     private void logBannerAction(Banner banner, Long adminId, String actionCodeStr) {

--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -31,6 +31,8 @@ public class SecurityConfig {
                         .disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+
                         .requestMatchers(
                                 "/",                // 루트 경로 (index.html)
                                 "/index.html",      // 메인 정적 페이지

--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                         .disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        //.requestMatchers("/api/admin/**").hasRole("ADMIN")
 
                         .requestMatchers(
                                 "/",                // 루트 경로 (index.html)

--- a/src/main/java/com/fairing/fairplay/event/repository/EventRepository.java
+++ b/src/main/java/com/fairing/fairplay/event/repository/EventRepository.java
@@ -27,4 +27,9 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventQueryR
     List<Event> findByManager_User_UserId(Long userId);
 
     Optional<Event> findByEventCode(String eventCode);
+
+    // 생성일 기준 최신순 상위 N개
+    List<Event> findAllByOrderByEventDetail_CreatedAtDesc(Pageable pageable);
+    List<Event> findByEventDetailIsNotNullOrderByEventDetail_CreatedAtDesc(Pageable pageable);
+
 }


### PR DESCRIPTION
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 만료 배너 자동 비활성화(매일 01:01).
  - 핫픽 배너 자동 갱신(매일 02:00, 최대 5개, 예약 기반 순위 사용).
  - 최신 이벤트 기반 NEW 배너 자동 생성(기본 노출 7일).
  - 관리자 전용 API로 신규/핫픽 배치 수동 실행 가능.

- Improvements
  - 배너 이미지 입력을 선택형으로 변경 및 S3 업로드 흐름 통합.
  - MD_PICK 배너는 동시에 1개만 활성화되도록 자동 정리.
  - 배너 노출 기간 검증(시작/종료 일자 유효성) 추가.

- Security
  - 관리자 권한 관련 규칙은 주석 처리되어 기능적 변경 없음.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->