### PR TITLE
feat: QR 티켓 발급, 마이페이지 조회, 새로고침 프론트 연결

### DIFF
--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -69,7 +69,8 @@ public class SecurityConfig {
                                 "/api/events/apply/check",
                                 "/api/events/user/role",
                                 "/api/super-admin/**",
-                                "/api/rag/**" // RAG API (개발/테스트용)
+                                "/api/rag/**", // RAG API (개발/테스트용)
+                                "/api/qr-tickets/admin/issue" // QR 티켓 강제 재발급 (테스트용)
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/reviews/*").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/form").permitAll()

--- a/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
+++ b/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
@@ -14,6 +14,7 @@ import com.fairing.fairplay.qr.dto.QrTicketResponseDto;
 import com.fairing.fairplay.qr.dto.QrTicketUpdateResponseDto;
 import com.fairing.fairplay.qr.dto.scan.QrCheckRequestDto;
 import com.fairing.fairplay.qr.service.EntryExitService;
+import com.fairing.fairplay.qr.service.QrTicketBatchService;
 import com.fairing.fairplay.qr.service.QrTicketService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +33,7 @@ public class QrTicketController {
 
   private final QrTicketService qrTicketService;
   private final EntryExitService entryExitService;
+  private final QrTicketBatchService qrTicketBatchService;
 
   // 마이페이지에서 QR 티켓 조회
   @PostMapping
@@ -114,5 +116,10 @@ public class QrTicketController {
   public ResponseEntity<CheckResponseDto> adminForceCheck(
       @RequestBody AdminForceCheckRequestDto dto) {
     return ResponseEntity.ok(entryExitService.adminForceCheck(dto));
+  }
+
+  @PostMapping("/admin/issue")
+  public void adminForceIssue(){
+    qrTicketService.adminForceIssue();
   }
 }

--- a/src/main/java/com/fairing/fairplay/qr/dto/QrTicketResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/qr/dto/QrTicketResponseDto.java
@@ -15,6 +15,7 @@ public class QrTicketResponseDto {
 
   private String title; // 행사명
   private String buildingName; //행사 장소
+  private String address;
   private String qrCode; // qr이미지 코드
   private String manualCode; // 수동 코드
   private String ticketNo; // 티켓 번호
@@ -26,10 +27,11 @@ public class QrTicketResponseDto {
    *
    * @see com.fairing.fairplay.qr.repository.QrTicketRepository#findDtoById(Long)
    */
-  public QrTicketResponseDto(String title, String buildingName,
+  public QrTicketResponseDto(String title, String buildingName, String address,
       String ticketNo, String qrCode, String manualCode) {
     this.title = title;
     this.buildingName = buildingName;
+    this.address = address;
     this.ticketNo = ticketNo;
     this.qrCode = qrCode;
     this.manualCode = manualCode;

--- a/src/main/java/com/fairing/fairplay/qr/dto/QrTicketResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/qr/dto/QrTicketResponseDto.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class QrTicketResponseDto {
 
+  private Long qrTicketId;
   private String title; // 행사명
   private String buildingName; //행사 장소
   private String address;
@@ -27,8 +28,9 @@ public class QrTicketResponseDto {
    *
    * @see com.fairing.fairplay.qr.repository.QrTicketRepository#findDtoById(Long)
    */
-  public QrTicketResponseDto(String title, String buildingName, String address,
+  public QrTicketResponseDto(Long qrTicketId, String title, String buildingName, String address,
       String ticketNo, String qrCode, String manualCode) {
+    this.qrTicketId = qrTicketId;
     this.title = title;
     this.buildingName = buildingName;
     this.address = address;

--- a/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
@@ -14,6 +14,7 @@ public interface QrTicketRepository extends JpaRepository<QrTicket, Long> {
 
   @Query("""
           SELECT new com.fairing.fairplay.qr.dto.QrTicketResponseDto(
+            q.id,
             e.titleKr,
             l.buildingName,
             l.address,

--- a/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
@@ -16,6 +16,7 @@ public interface QrTicketRepository extends JpaRepository<QrTicket, Long> {
           SELECT new com.fairing.fairplay.qr.dto.QrTicketResponseDto(
             e.titleKr,
             l.buildingName,
+            l.address,
             q.ticketNo,
             q.qrCode,
             q.manualCode)


### PR DESCRIPTION
## 변경 사항
- QR 티켓 조회 시 예약 ID와 티켓 ID 반환

## 추가 사항
- 예약 완료 후 참석자 정보 저장 및 참석자 폼링크제공 추가 예정

## 관련 이슈
- #36 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 관리자용 QR 티켓 강제 발급 엔드포인트가 추가되었습니다: POST /api/qr-tickets/admin/issue. 테스트 편의를 위해 인증 없이 접근 가능합니다.
  - QR 티켓 조회 응답에 티켓 ID와 주소가 포함되어, 조회 시 더 풍부한 정보를 확인할 수 있습니다.
  - 공개 접근 경로가 업데이트되어 인증 없이 사용 가능한 영역이 명확해졌습니다(예: /api/rag/**).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->