### PR TITLE
feat: md_pick 두개 설정으로 변경

### DIFF
--- a/src/main/java/com/fairing/fairplay/banner/dto/BannerRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/banner/dto/BannerRequestDto.java
@@ -28,7 +28,6 @@ public class BannerRequestDto {
 
     @NotNull
     private Long bannerTypeId;
-    private boolean hot;
-    private boolean mdPick;
+
 
 }

--- a/src/main/java/com/fairing/fairplay/banner/repository/BannerRepository.java
+++ b/src/main/java/com/fairing/fairplay/banner/repository/BannerRepository.java
@@ -85,4 +85,20 @@ public interface BannerRepository extends JpaRepository<Banner, Long> {
     boolean existsByBannerType_CodeAndEventIdAndBannerStatusCode_Code(
             String typeCode, Long eventId, String statusCode
     );
+
+    // MD_PICK 활성 개수 카운트
+    long countByBannerType_CodeAndBannerStatusCode_Code(
+            String typeCode, String statusCode
+    );
+
+    // MD_PICK 활성 목록 (우선순위 오름차순) — 초과 시 꼬리 자르기에 사용
+    List<Banner> findAllByBannerType_CodeAndBannerStatusCode_CodeOrderByPriorityAsc(
+            String typeCode, String statusCode
+    );
+
+    // (업데이트 상황용) 자신 제외하고 활성 목록 (우선순위 오름차순)
+    List<Banner> findAllByBannerType_CodeAndBannerStatusCode_CodeAndIdNotOrderByPriorityAsc(
+            String typeCode, String statusCode, Long excludeId
+    );
+
 }

--- a/src/main/java/com/fairing/fairplay/banner/service/BannerService.java
+++ b/src/main/java/com/fairing/fairplay/banner/service/BannerService.java
@@ -43,6 +43,7 @@ public class BannerService {
     private final BannerTypeRepository bannerTypeRepository;
     private final EventRepository eventRepository;
 
+
     @Value("${cloud.aws.s3.banner-dir:banner}")
     private String bannerDir;
 
@@ -79,9 +80,9 @@ public class BannerService {
         Banner saved = bannerRepository.save(banner);
 
         if (TYPE_MD_PICK.equals(bannerType.getCode()) && STATUS_ACTIVE.equals(statusCode.getCode())) {
-            BannerStatusCode inactive = getStatusCodeOr404(STATUS_INACTIVE);
-            bannerRepository.deactivateOthersActiveByType(TYPE_MD_PICK, STATUS_ACTIVE, inactive, saved.getId());
+            enforceMdPickMaxActive(2, adminId);
         }
+
 
         String finalImageUrl = resolveImageUrlForCreate(dto, saved.getId());
         saved.setImageUrl(finalImageUrl);
@@ -117,20 +118,16 @@ public class BannerService {
                 dto.getTitle(),
                 finalImageUrl,
                 dto.getLinkUrl(),
-                dto.getStartDate(),
-                dto.getEndDate(),
+                newStart,
+                newEnd,
                 dto.getPriority(),
                 bannerType
         );
         banner.updateStatus(statusCode);
 
-// MD_PICK 하나만 유지: 결과가 MD_PICK + ACTIVE면 자기 자신 제외 모두 INACTIVE
         if (TYPE_MD_PICK.equals(banner.getBannerType().getCode())
                 && STATUS_ACTIVE.equals(banner.getBannerStatusCode().getCode())) {
-            BannerStatusCode inactive = getStatusCodeOr404(STATUS_INACTIVE);
-            bannerRepository.deactivateOthersActiveByType(
-                    TYPE_MD_PICK, STATUS_ACTIVE, inactive, banner.getId()
-            );
+            enforceMdPickMaxActive(2, adminId);
         }
 
         logBannerAction(banner, adminId, ACTION_UPDATE);
@@ -145,13 +142,28 @@ public class BannerService {
         banner.updateStatus(statusCode);
         logBannerAction(banner, adminId, ACTION_UPDATE);
 
-        //  MD_PICK을 ACTIVE로 바꾸면, 자신 제외 모두 INACTIVE
         if (TYPE_MD_PICK.equals(banner.getBannerType().getCode())
                 && STATUS_ACTIVE.equals(statusCode.getCode())) {
-            BannerStatusCode inactive = getStatusCodeOr404(STATUS_INACTIVE);
-            bannerRepository.deactivateOthersActiveByType(
-                    TYPE_MD_PICK, STATUS_ACTIVE, inactive, banner.getId()
-            );
+            enforceMdPickMaxActive(2, adminId);
+        }
+
+    }
+
+    private void enforceMdPickMaxActive(int maxKeep,  Long adminId){
+        // 우선순위 오름차순 기준: 작은 priority가 더 상위라고 가정
+        List<Banner> actives = bannerRepository
+                .findAllByBannerType_CodeAndBannerStatusCode_CodeOrderByPriorityAsc(TYPE_MD_PICK, STATUS_ACTIVE);
+
+        if (actives.size() <= maxKeep) return;
+
+        BannerStatusCode inactive = getStatusCodeOr404(STATUS_INACTIVE);
+
+        // 상위 maxKeep만 남기고 꼬리부터 INACTIVE
+        for (int i = maxKeep; i < actives.size(); i++) {
+            Banner toDeactivate = actives.get(i);
+            toDeactivate.updateStatus(inactive);
+            // 필요하면 이력 남김
+            logBannerAction(toDeactivate, adminId, ACTION_UPDATE);
         }
     }
 
@@ -254,6 +266,7 @@ public class BannerService {
 
         bannerLogRepository.save(log);
     }
+
 
     private Banner getBannerOr404(Long id) {
         return bannerRepository.findById(id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - MD PICK 배너 활성 상태 관리 일관화: 생성/수정/상태 변경 시 최대 2개만 활성, 초과분은 우선순위가 낮은 항목부터 자동 비활성화되어 노출 안정성 개선.
- New Features
  - 활성 MD PICK 배너를 우선순위 오름차순으로 자동 유지하여 노출 품질 향상.
- Refactor
  - 배너 생성/수정 요청에서 hot, mdPick 필드 제거. 관리자 화면/클라이언트는 해당 옵션을 더 이상 표시·전송하지 않도록 업데이트 필요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->