### PR TITLE
feat: 검색 상단 고정 구현

### DIFF
--- a/src/main/java/com/fairing/fairplay/banner/controller/BannerPublicQueryController.java
+++ b/src/main/java/com/fairing/fairplay/banner/controller/BannerPublicQueryController.java
@@ -1,0 +1,28 @@
+// com.fairing.fairplay.banner.controller.BannerPublicQueryController.java
+package com.fairing.fairplay.banner.controller;
+
+import com.fairing.fairplay.banner.dto.FixedTopDto;
+import com.fairing.fairplay.banner.service.SearchTopQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/banner")
+public class BannerPublicQueryController {
+
+    private final SearchTopQueryService searchTopQueryService;
+
+    @GetMapping("/search-top")
+    public List<FixedTopDto> getSearchTop(
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        LocalDate d = (date != null) ? date : LocalDate.now();
+        return searchTopQueryService.getFixedTwo(d);
+    }
+}

--- a/src/main/java/com/fairing/fairplay/banner/controller/BannerSlotController.java
+++ b/src/main/java/com/fairing/fairplay/banner/controller/BannerSlotController.java
@@ -2,6 +2,7 @@ package com.fairing.fairplay.banner.controller;
 
 import com.fairing.fairplay.banner.dto.SlotResponseDto;
 import com.fairing.fairplay.banner.entity.BannerSlotType;
+import com.fairing.fairplay.banner.service.BannerService;
 import com.fairing.fairplay.banner.service.BannerSlotService;
 import com.fairing.fairplay.core.security.CustomUserDetails;
 import jakarta.validation.constraints.NotNull;
@@ -11,6 +12,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import com.fairing.fairplay.banner.dto.LockSlotsRequestDto;
+import com.fairing.fairplay.banner.dto.LockSlotsResponseDto;
+import com.fairing.fairplay.banner.dto.FinalizeSoldRequestDto;
+import com.fairing.fairplay.banner.dto.FinalizeSoldResponseDto;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -24,6 +29,7 @@ import org.springframework.web.server.ResponseStatusException;
 @Validated
 public class BannerSlotController {
     private final BannerSlotService slotService;
+    private final BannerService bannerService;
 
     private void requireLogin(CustomUserDetails user) {
         if (user == null) {
@@ -50,4 +56,25 @@ public class BannerSlotController {
         }
         return ResponseEntity.ok(slotService.getSlots(type, from, to));
 
-    }}
+
+
+    }
+    @PostMapping("/slots/lock")
+    public ResponseEntity<LockSlotsResponseDto> lockSlots(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody LockSlotsRequestDto req
+    ) {
+        requireLogin(user);
+        return ResponseEntity.ok(bannerService.lockSlots(req, user.getUserId()));
+    }
+
+    @PostMapping("/slots/sold")
+    public ResponseEntity<FinalizeSoldResponseDto> finalizeSold(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody FinalizeSoldRequestDto req
+    ) {
+        requireLogin(user);
+        return ResponseEntity.ok(bannerService.finalizeSold(req, user.getUserId()));
+    }
+
+}

--- a/src/main/java/com/fairing/fairplay/banner/dto/FinalizeSoldRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/banner/dto/FinalizeSoldRequestDto.java
@@ -1,0 +1,11 @@
+package com.fairing.fairplay.banner.dto;
+
+import java.util.List;
+
+public record FinalizeSoldRequestDto(
+        List<Long> slotIds,      // LOCK 상태였던 슬롯들
+        Long eventId,            // 고정 노출시킬 이벤트
+        String title,            // 배너 타이틀(선택)
+        String imageUrl,
+        String linkUrl
+) {}

--- a/src/main/java/com/fairing/fairplay/banner/dto/FinalizeSoldResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/banner/dto/FinalizeSoldResponseDto.java
@@ -1,0 +1,7 @@
+package com.fairing.fairplay.banner.dto;
+
+import java.util.List;
+
+public record FinalizeSoldResponseDto(
+        List<Long> bannerIds     // 생성된 banner_id 목록(슬롯별 1개씩)
+) {}

--- a/src/main/java/com/fairing/fairplay/banner/dto/FixedTopDto.java
+++ b/src/main/java/com/fairing/fairplay/banner/dto/FixedTopDto.java
@@ -1,0 +1,7 @@
+package com.fairing.fairplay.banner.dto;
+
+public record FixedTopDto(
+        Long eventId,
+        Integer priority,
+        boolean mdPick
+) {}

--- a/src/main/java/com/fairing/fairplay/banner/dto/LockSlotsRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/banner/dto/LockSlotsRequestDto.java
@@ -1,0 +1,13 @@
+package com.fairing.fairplay.banner.dto;
+
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record LockSlotsRequestDto(
+        String typeCode,             // 'SEARCH_TOP' 또는 'HERO'
+        List<Item> items,            // 잠글 (날짜, 우선순위) 목록
+        Integer holdHours            // null이면 48시간
+) {
+    public record Item(LocalDate slotDate, Integer priority) {}
+}

--- a/src/main/java/com/fairing/fairplay/banner/dto/LockSlotsResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/banner/dto/LockSlotsResponseDto.java
@@ -1,0 +1,10 @@
+package com.fairing.fairplay.banner.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record LockSlotsResponseDto(
+        List<Long> slotIds,          // 잠금된 slot_id들
+        Integer totalAmount,         // 가격 합계(슬롯 price 합)
+        LocalDateTime lockedUntil    // 만료 시각
+) {}

--- a/src/main/java/com/fairing/fairplay/banner/service/SearchTopQueryService.java
+++ b/src/main/java/com/fairing/fairplay/banner/service/SearchTopQueryService.java
@@ -1,0 +1,23 @@
+package com.fairing.fairplay.banner.service;
+
+import com.fairing.fairplay.banner.dto.FixedTopDto;
+import com.fairing.fairplay.banner.repository.BannerSlotRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SearchTopQueryService {
+    private final BannerSlotRepository slotRepo;
+
+    public List<FixedTopDto> getFixedTwo(LocalDate date) {
+        return slotRepo.findSoldFixedRows("SEARCH_TOP", date)
+                .stream()
+                .limit(2) // 두 칸만
+                .map(r -> new FixedTopDto(r.getEventId(), r.getPriority(), true))
+                .toList();
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 검색 상단 영역 고정 배너 2개 조회 API 추가(선택적 날짜 파라미터 지원).
  - 배너 슬롯 잠금 API 추가: 선택한 슬롯을 일정 시간 동안 홀드하고 총액·만료시각을 반환(로그인 필요).
  - 결제 완료 처리 API 추가: 잠금된 슬롯을 판매 확정하고 생성된 배너 ID 목록 반환(로그인 필요).
- Refactor
  - MD Pick 배너의 단일 노출 강제 규칙 제거(동시 노출 가능).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->