### PR TITLE
feat: slot, adminbannerbatch 권한 수정

### DIFF
--- a/src/main/java/com/fairing/fairplay/banner/controller/AdminBannerBatchController.java
+++ b/src/main/java/com/fairing/fairplay/banner/controller/AdminBannerBatchController.java
@@ -3,28 +3,43 @@ package com.fairing.fairplay.banner.controller;
 
 import com.fairing.fairplay.banner.batch.HotPickScheduler;
 import com.fairing.fairplay.banner.batch.NewPickScheduler;
+import com.fairing.fairplay.core.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/admin/batch")
 @RequiredArgsConstructor
 public class AdminBannerBatchController {
+    private static final String ROLE_ADMIN = "ADMIN";
 
     private final NewPickScheduler newPickScheduler;
+    private final HotPickScheduler hotPickScheduler;
+
+    private void requireAdmin(CustomUserDetails user) {
+        if (user == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        if (!ROLE_ADMIN.equals(user.getRoleCode())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "관리자만 접근할 수 있습니다.");
+        }
+    }
 
     @PostMapping("/new-picks/run")
-    public ResponseEntity<Void> runNewPicks() {
+    public ResponseEntity<Void> runNewPicks(@AuthenticationPrincipal CustomUserDetails user) {
+            requireAdmin(user);
         newPickScheduler.updateNewPicks();
         return ResponseEntity.ok().build();
     }
 
-    private final HotPickScheduler hotPickScheduler;
-
     @PostMapping("/hot-picks/run")
-    public ResponseEntity<Void> runHotPicks() {
+    public ResponseEntity<Void> runHotPicks(@AuthenticationPrincipal CustomUserDetails user) {
+            requireAdmin(user);
         hotPickScheduler.updateHotPicks();
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/fairing/fairplay/banner/controller/BannerSlotController.java
+++ b/src/main/java/com/fairing/fairplay/banner/controller/BannerSlotController.java
@@ -5,6 +5,7 @@ import com.fairing.fairplay.banner.entity.BannerSlotType;
 import com.fairing.fairplay.banner.service.BannerService;
 import com.fairing.fairplay.banner.service.BannerSlotService;
 import com.fairing.fairplay.core.security.CustomUserDetails;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -28,14 +29,38 @@ import org.springframework.web.server.ResponseStatusException;
 @RequestMapping("/api/banner")
 @Validated
 public class BannerSlotController {
+
+    private static final String ROLE_ADMIN = "ADMIN";
+    private static final String ROLE_EVENT_MANAGER = "EVENT_MANAGER";
+
     private final BannerSlotService slotService;
     private final BannerService bannerService;
 
+    /** 공통: 로그인만 필요 */
     private void requireLogin(CustomUserDetails user) {
         if (user == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
         }
     }
+
+    /** 행사담당자 또는 관리자 */
+    private void requireEventManagerOrAdmin(CustomUserDetails user) {
+        requireLogin(user);
+        String role = user.getRoleCode();
+        if (!ROLE_ADMIN.equals(role) && !ROLE_EVENT_MANAGER.equals(role)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "행사담당자 또는 관리자만 접근할 수 있습니다.");
+        }
+    }
+
+    /** 관리자 전용 */
+    private void requireAdmin(CustomUserDetails user) {
+        requireLogin(user);
+        if (!ROLE_ADMIN.equals(user.getRoleCode())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "관리자만 접근할 수 있습니다.");
+        }
+    }
+
+
 
 
     @GetMapping("/slots")
@@ -56,24 +81,25 @@ public class BannerSlotController {
         }
         return ResponseEntity.ok(slotService.getSlots(type, from, to));
 
-
-
     }
+
+    // 신청 : 행사 담당자, 관리자
     @PostMapping("/slots/lock")
     public ResponseEntity<LockSlotsResponseDto> lockSlots(
             @AuthenticationPrincipal CustomUserDetails user,
-            @RequestBody LockSlotsRequestDto req
+            @RequestBody @Valid LockSlotsRequestDto req
     ) {
-        requireLogin(user);
+        requireEventManagerOrAdmin(user);
         return ResponseEntity.ok(bannerService.lockSlots(req, user.getUserId()));
     }
 
+    // 결제 완료 : 관리자만
     @PostMapping("/slots/sold")
     public ResponseEntity<FinalizeSoldResponseDto> finalizeSold(
             @AuthenticationPrincipal CustomUserDetails user,
-            @RequestBody FinalizeSoldRequestDto req
+            @RequestBody @Valid FinalizeSoldRequestDto req
     ) {
-        requireLogin(user);
+        requireAdmin(user);
         return ResponseEntity.ok(bannerService.finalizeSold(req, user.getUserId()));
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 배치 실행 엔드포인트에 관리자 전용 접근 제어를 도입해 비인가 실행을 차단합니다.
  * 배너 슬롯 조회는 로그인 필수로 변경되었습니다.
  * 배너 슬롯 잠금은 이벤트 매니저 또는 관리자만 수행할 수 있습니다.
  * 판매 확정은 관리자만 수행할 수 있습니다.
  * 요청 데이터 유효성 검증을 추가해 잘못된 입력을 사전에 차단합니다.
  * 인증/권한 오류 시 한국어 안내 메시지를 제공해 피드백을 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->