### PR TITLE
feat: 만료 시간에 따른 접근 제한

### DIFF
--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -75,6 +75,8 @@ public class SecurityConfig {
                                 "/api/rag/**", // RAG API (개발/테스트용)
                                 "/api/qr-tickets/admin/issue", // QR 티켓 강제 재발급 (테스트용)
                                 "/api/rag/**", // RAG API (개발/테스트용)
+                                "/api/qr-tickets/check-in/*", // 테스트 후 수정 예정
+                                "/api/qr-tickets/check-out/*", // 테스트 후 수정 예정
                                 "/api/events/*/booths/**",
                                 "/api/events/{eventId}/booths/apply",
                                 "/api/booths/cancel/**",

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketEntryService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketEntryService.java
@@ -55,6 +55,10 @@ public class QrTicketEntryService {
         () -> new CustomException(HttpStatus.NOT_FOUND, "올바르지 않은 QR 코드입니다.")
     );
 
+    LocalDateTime now = LocalDateTime.now(); // 현재일시
+    if(now.isAfter(qrTicket.getExpiredAt())){
+      throw new CustomException(HttpStatus.BAD_REQUEST, "행사가 종료되었습니다.");
+    }
 
     // QR 티켓 참석자 조회
     Attendee attendee = qrTicket.getAttendee();
@@ -91,6 +95,11 @@ public class QrTicketEntryService {
     QrTicket qrTicket = qrTicketRepository.findByManualCode(dto.getManualCode()).orElseThrow(
         () -> new CustomException(HttpStatus.NOT_FOUND, "올바르지 않은 수동 코드입니다.")
     );
+
+    LocalDateTime now = LocalDateTime.now(); // 현재일시
+    if(now.isAfter(qrTicket.getExpiredAt())){
+      throw new CustomException(HttpStatus.BAD_REQUEST, "행사가 종료되었습니다.");
+    }
 
     // QR 티켓에 저장된 참석자 조회
     Attendee attendee = qrTicket.getAttendee();

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketExitService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketExitService.java
@@ -47,6 +47,11 @@ public class QrTicketExitService {
         () -> new CustomException(HttpStatus.NOT_FOUND, "올바르지 않은 QR 코드입니다.")
     );
 
+    LocalDateTime now = LocalDateTime.now(); // 현재일시
+    if(now.isAfter(qrTicket.getExpiredAt())){
+      throw new CustomException(HttpStatus.BAD_REQUEST, "행사가 종료되었습니다.");
+    }
+
     // QR 티켓 참석자 조회
     Attendee attendee = qrTicket.getAttendee();
     AttendeeTypeCode primaryTypeCode = qrTicketAttendeeService.findPrimaryTypeCode();
@@ -82,6 +87,11 @@ public class QrTicketExitService {
     QrTicket qrTicket = qrTicketRepository.findByManualCode(dto.getManualCode()).orElseThrow(
         () -> new CustomException(HttpStatus.NOT_FOUND, "올바르지 않은 수동 코드입니다.")
     );
+
+    LocalDateTime now = LocalDateTime.now(); // 현재일시
+    if(now.isAfter(qrTicket.getExpiredAt())){
+      throw new CustomException(HttpStatus.BAD_REQUEST, "행사가 종료되었습니다.");
+    }
 
     // QR 티켓에 저장된 참석자 조회
     Attendee attendee = qrTicket.getAttendee();


### PR DESCRIPTION
## 변경 사항
- 행사 만료 시간에 맞춰 QR 티켓 접근 제한

## 추가 사항
- API 테스트 완료

## 관련 이슈
- #36 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - QR 티켓 체크인/체크아웃 API를 인증 없이 접근 가능하도록 일시적으로 공개 범위에 추가했습니다(테스트용). 다른 엔드포인트의 보안 정책은 변경되지 않습니다.
- 버그 수정
  - 만료된 행사에 대한 체크인/체크아웃 시도를 사전에 차단하는 만료 검증을 추가했습니다. 만료 시 400 오류와 “행사가 종료되었습니다.” 메시지를 반환하며, QR 스캔과 수기 입력 흐름 모두에 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->