### PR TITLE
feat: 광고 신청 목록 구현

### DIFF
--- a/src/main/java/com/fairing/fairplay/banner/controller/AdminBannerController.java
+++ b/src/main/java/com/fairing/fairplay/banner/controller/AdminBannerController.java
@@ -157,4 +157,28 @@ public class AdminBannerController {
         requireAdmin(user);
         return ResponseEntity.ok(bannerService.getOne(id));
     }
+
+    /** 승인(결제 확인 완료) → SOLD & banner 생성 */
+    @PostMapping("/applications/{id}/approve")
+    public ResponseEntity<Void> approve(
+            @AuthenticationPrincipal CustomUserDetails admin,
+            @PathVariable Long id
+    ) {
+        requireAdmin(admin);
+        appService.markPaid(id, admin.getUserId());   // 이미 구현됨
+        return ResponseEntity.noContent().build();
+    }
+
+    /** 반려 → 신청 상태 REJECTED, 잠금 슬롯 원복 */
+    @PostMapping("/applications/{id}/reject")
+    public ResponseEntity<Void> reject(
+            @AuthenticationPrincipal CustomUserDetails admin,
+            @PathVariable Long id,
+            @RequestBody(required = false) Map<String, String> body
+    ) {
+        requireAdmin(admin);
+        String reason = body != null ? body.getOrDefault("reason", null) : null;
+        appService.reject(id, admin.getUserId(), reason);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/fairing/fairplay/banner/service/BannerApplicationService.java
+++ b/src/main/java/com/fairing/fairplay/banner/service/BannerApplicationService.java
@@ -333,47 +333,57 @@ public class BannerApplicationService {
         }
 
         // 3) 신청 상태 승인 처리
-        jdbc.update("""
-                UPDATE banner_application
-                SET status_code_id = (SELECT apply_status_code_id FROM apply_status_code WHERE code=?),
-                    approved_by=?, approved_at=NOW()
-                WHERE banner_application_id=?
-                """, STATUS_APPROVED, adminId, appId);
+        int updated = jdbc.update("""
+                  UPDATE banner_application
+                     SET status_code_id = (SELECT apply_status_code_id FROM apply_status_code WHERE code='APPROVED'),
+                         approved_by=?, approved_at=NOW()
+                   WHERE banner_application_id=? 
+                     AND status_code_id = (SELECT apply_status_code_id FROM apply_status_code WHERE code='PENDING')
+                """, adminId, appId);
+        if (updated != 1) throw new IllegalStateException("신청 상태가 변경되어 승인 처리에 실패했습니다.");
     }
 
-    // com.fairing.fairplay.banner.service.BannerApplicationService
-    @Transactional
-    public void reject(Long appId, Long adminId, String reason) {
-        // 현재 신청 상태 확인 (PENDING 인지 등)
-        Map<String, Object> app = jdbc.queryForMap(
-                "SELECT status_code_id FROM banner_application WHERE banner_application_id=?",
-                appId
-        );
-        Integer pendingId = statusId(STATUS_PENDING);
-        if (!Objects.equals(((Number)app.get("status_code_id")).intValue(), pendingId)) {
-            throw new IllegalStateException("반려할 수 없는 상태입니다.");
+        // com.fairing.fairplay.banner.service.BannerApplicationService
+        @Transactional
+        public void reject (Long appId, Long adminId, String reason){
+            // 현재 신청 상태 확인 (PENDING 인지 등)
+            Integer pendingId = statusId(STATUS_PENDING);
+            Integer currentStatus;
+            try {
+                currentStatus = jdbc.queryForObject(
+                        "SELECT status_code_id FROM banner_application WHERE banner_application_id=? FOR UPDATE",
+                        Integer.class, appId
+                );
+            } catch (EmptyResultDataAccessException e) {
+                throw new IllegalArgumentException("존재하지 않는 신청입니다: " + appId);
+            }
+            if (!Objects.equals(currentStatus, pendingId)) {
+                throw new IllegalStateException("반려할 수 없는 상태입니다.");
+            }
+
+            // 잠금 슬롯 되돌리기 (LOCKED → AVAILABLE, 본인 소유자 여부는 묻지 않음: 관리자 권한)
+            List<Long> slotIds = jdbc.queryForList("""
+                        SELECT slot_id FROM banner_application_slot WHERE banner_application_id=?
+                    """, Long.class, appId);
+
+            if (!slotIds.isEmpty()) {
+                namedJdbc.update("""
+                            UPDATE banner_slot
+                               SET status='AVAILABLE', locked_by=NULL, locked_until=NULL
+                             WHERE slot_id IN (:slotIds) AND status='LOCKED'
+                        """, new MapSqlParameterSource().addValue("slotIds", slotIds));
+            }
+
+            // 신청 상태 REJECTED + 사유 기록
+            int updated = jdbc.update("""
+                      UPDATE banner_application
+                         SET status_code_id = (SELECT apply_status_code_id FROM apply_status_code WHERE code='REJECTED'),
+                             admin_comment = ?, approved_by=?, approved_at=NOW()
+                       WHERE banner_application_id=? 
+                         AND status_code_id = (SELECT apply_status_code_id FROM apply_status_code WHERE code='PENDING')
+                    """, reason, adminId, appId);
+            if (updated != 1) throw new IllegalStateException("신청 상태가 변경되어 반려 처리에 실패했습니다.");
+
+
         }
-
-        // 잠금 슬롯 되돌리기 (LOCKED → AVAILABLE, 본인 소유자 여부는 묻지 않음: 관리자 권한)
-        List<Long> slotIds = jdbc.queryForList("""
-        SELECT slot_id FROM banner_application_slot WHERE banner_application_id=?
-    """, Long.class, appId);
-
-        if (!slotIds.isEmpty()) {
-            namedJdbc.update("""
-            UPDATE banner_slot
-               SET status='AVAILABLE', locked_by=NULL, locked_until=NULL
-             WHERE slot_id IN (:slotIds) AND status='LOCKED'
-        """, new MapSqlParameterSource().addValue("slotIds", slotIds));
-        }
-
-        // 신청 상태 REJECTED + 사유 기록
-        jdbc.update("""
-        UPDATE banner_application
-           SET status_code_id = (SELECT apply_status_code_id FROM apply_status_code WHERE code='REJECTED'),
-               admin_comment = ?, approved_by=?, approved_at=NOW()
-         WHERE banner_application_id=?
-    """, reason, adminId, appId);
     }
-
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 관리자용 배너 신청 처리 API 추가: 관리자가 신청을 승인(approve)하거나 반려(reject)할 수 있습니다.
  - 반려 시 사유를 선택적으로 입력 가능하며 입력된 사유가 기록됩니다.
  - 승인/반려는 신청 상태가 대기(PENDING)일 때만 적용되어 중복 또는 잘못된 상태 변경을 방지합니다.
  - 반려 시 해당 신청에 예약된 슬롯이 자동으로 해제됩니다.

- 기타
  - 성공 응답은 본문 없는 204로 일관됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->