### PR TITLE
fix: 행사 목록 조회 버그 수정

### DIFF
--- a/src/main/java/com/fairing/fairplay/event/controller/EventController.java
+++ b/src/main/java/com/fairing/fairplay/event/controller/EventController.java
@@ -121,12 +121,18 @@ public class EventController {
             @RequestParam(required = false) Integer mainCategoryId,
             @RequestParam(required = false) Integer subCategoryId,
             @RequestParam(required = false) String regionName,
+            @RequestParam(required = false) Boolean includeHidden,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate,
             @PageableDefault(size = 10) Pageable pageable,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        if (includeHidden == true && !ADMIN_ROLE.equals(userDetails.getRoleCode())) {
+            throw new CustomException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+        }
+
         EventSummaryResponseDto response = eventService.getEvents(keyword, mainCategoryId, subCategoryId, regionName,
-                fromDate, toDate, userDetails, pageable);
+                fromDate, toDate, includeHidden, pageable);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/fairing/fairplay/event/service/EventService.java
+++ b/src/main/java/com/fairing/fairplay/event/service/EventService.java
@@ -205,7 +205,7 @@ public class EventService {
     public EventSummaryResponseDto getEvents(
             String keyword, Integer mainCategoryId, Integer subCategoryId,
             String regionName, LocalDate fromDate, LocalDate toDate,
-            CustomUserDetails userDetails, Pageable pageable) {
+            Boolean includeHidden, Pageable pageable) {
         log.info("행사 목록 조회 필터");
         log.info("keyword : {}", keyword);
         log.info("mainCategoryId : {}", mainCategoryId);
@@ -213,11 +213,6 @@ public class EventService {
         log.info("regionName : {}", regionName);
         log.info("fromDate : {}", fromDate);
         log.info("toDate : {}", toDate);
-        
-        // 관리자 권한 확인
-        boolean includeHidden = userDetails != null && "ADMIN".equals(userDetails.getRoleCode());
-        log.info("사용자 권한: {}, 숨겨진 행사 포함 여부: {}", 
-                userDetails != null ? userDetails.getRoleCode() : "비로그인", includeHidden);
 
         Page<EventSummaryDto> eventPage = eventQueryRepository.findEventSummariesWithFilters (
                 keyword, mainCategoryId, subCategoryId, regionName, fromDate, toDate, includeHidden, pageable);


### PR DESCRIPTION
전체 관리자 로그인 시 메인/검색 화면에서 숨김 상태 행사도 표시됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 이벤트 목록 조회 API에 선택적 includeHidden 파라미터가 추가되어, 필요 시 숨김 이벤트를 함께 조회할 수 있습니다.
  - 보안 및 접근 제어가 강화되어, includeHidden=true는 관리자에게만 허용됩니다. 비관리자 계정이 사용할 경우 403 Forbidden과 “접근 권한이 없습니다.” 메시지가 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->