### PR TITLE
feat: 참석자 폼 조회 로직 수정

### DIFF
--- a/src/main/java/com/fairing/fairplay/shareticket/repository/ShareTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/repository/ShareTicketRepository.java
@@ -2,11 +2,14 @@ package com.fairing.fairplay.shareticket.repository;
 
 import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.shareticket.entity.ShareTicket;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ShareTicketRepository extends JpaRepository<ShareTicket, Long> {
 
@@ -14,6 +17,16 @@ public interface ShareTicketRepository extends JpaRepository<ShareTicket, Long> 
 
   List<ShareTicket> findAllByExpiredAtLessThan(LocalDateTime endDate,
       Pageable pageable);
+
+  @Query("SELECT s FROM ShareTicket s " +
+      "WHERE s.expired = false " + // 아직 만료되지 않은 티켓
+      "AND s.expiredAt < :endDate " + // 오늘 만료 예정
+      "AND s.reservation.schedule.date <> :today") // 오늘 예약은 제외
+  List<ShareTicket> findAllExpiredExceptTodayReservations(
+      @Param("endDate") LocalDateTime endDate,
+      @Param("today") LocalDate today,
+      Pageable pageable
+  );
 
   boolean existsByLinkToken(String token);
 

--- a/src/main/java/com/fairing/fairplay/shareticket/repository/ShareTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/repository/ShareTicketRepository.java
@@ -21,7 +21,8 @@ public interface ShareTicketRepository extends JpaRepository<ShareTicket, Long> 
   @Query("SELECT s FROM ShareTicket s " +
       "WHERE s.expired = false " + // 아직 만료되지 않은 티켓
       "AND s.expiredAt < :endDate " + // 오늘 만료 예정
-      "AND s.reservation.schedule.date <> :today") // 오늘 예약은 제외
+      "AND s.reservation.schedule.date <> :today "+
+      "ORDER BY s.expiredAt ASC") // 오늘 예약은 제외
   List<ShareTicket> findAllExpiredExceptTodayReservations(
       @Param("endDate") LocalDateTime endDate,
       @Param("today") LocalDate today,

--- a/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketBatchService.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketBatchService.java
@@ -21,6 +21,7 @@ public class ShareTicketBatchService {
   private final ShareTicketRepository shareTicketRepository;
 
   // 만료 날짜가 오늘이고 아직 만료처리되지 않은 공유 폼 링크 조회
+  // 당일 예약이거나 행사 전날 예약했을 경우엔 제외
   public List<ShareTicket> fetchExpiredBatch(int page, int size) {
     Pageable pageable = PageRequest.of(page, size);
 
@@ -29,7 +30,7 @@ public class ShareTicketBatchService {
     LocalDateTime endDate = now.plusDays(1).atStartOfDay(); // 11
     log.info("fetchExpiredBatch startDate: {}, endDate: {}", startDate, endDate);
 
-    return shareTicketRepository.findAllByExpiredAtLessThan(endDate, pageable);
+    return shareTicketRepository.findAllExpiredExceptTodayReservations(endDate, now,  pageable);
   }
 
   // 공유 폼 링크 만료 -> 스케줄러 자동 실행


### PR DESCRIPTION
## 변경 사항
- 참석자 폼 조회 시 당일 예약 건 폼은 만료되지 않도록 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * 공유 티켓 만료 기준을 조정해 행사 전날·당일에는 토큰이 행사 시작 시각까지 유효하도록 변경하여 예기치 않은 조기 만료를 방지했습니다.
  * 오늘 일정의 예약은 만료 처리 대상에서 제외되어 사용 중인 티켓이 갑자기 비활성화되는 문제를 줄였습니다.
  * 이로써 입장 시 접근 거부 상황이 감소하고, 만료 목록·알림에서 오늘 티켓으로 인한 혼선이 줄어 전반적인 사용 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->