### PR TITLE
refactor: 관람평 작성 가능 행사 목록 조회 시 날짜 조건 삭제

### DIFF
--- a/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepository.java
@@ -42,7 +42,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
               JOIN r.event e
               LEFT JOIN r.ticket t
               WHERE r.user.userId = :userId
-                AND r.schedule.date <= CURRENT_DATE
                 AND r.canceled = false
               ORDER BY r.createdAt DESC
           """,
@@ -51,7 +50,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
       FROM Reservation r
       JOIN r.event e
       WHERE r.user.userId = :userId
-      AND r.schedule.date <= CURRENT_DATE
       AND r.canceled = false
       """)
   Page<PossibleReviewResponseDto> findPossibleReviewReservationsDto(@Param("userId") Long userId,

--- a/src/main/java/com/fairing/fairplay/review/service/ReviewReservationService.java
+++ b/src/main/java/com/fairing/fairplay/review/service/ReviewReservationService.java
@@ -6,10 +6,8 @@ import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.reservation.repository.ReservationRepository;
 import com.fairing.fairplay.review.dto.PossibleReviewResponseDto;
 import com.fairing.fairplay.review.repository.ReviewRepository;
-import com.fairing.fairplay.user.entity.Users;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -55,15 +53,18 @@ public class ReviewReservationService {
     // 1. 로그인한 사용자가 리뷰를 작성할 수 있는 모든 행사 목록 페이징
     Page<PossibleReviewResponseDto> reservations = reservationRepository.findPossibleReviewReservationsDto(
         userDetails.getUserId(), pageable);
+    log.info("Page<PossibleReviewResponseDto> reservations:{}", reservations.getSize());
 
     // 2. 페이지로 조회한 예약 DTO 목록에서 예약 ID만 뽑아 리스트 생성
     List<Long> reservationIds = reservations.getContent().stream()
         .map(PossibleReviewResponseDto::getReservationId)
         .collect(Collectors.toList());
+    log.info("Page<PossibleReviewResponseDto> reservations:{}", reservationIds.size());
 
     // 3. 1번에서 조회된 행사들의 reservationId 목록 이용해 작성자가 이미 작성한 리뷰가 있는 reservationId만 Set 형태로 가져옴
     Set<Long> reviewedIds = reservationIds.isEmpty() ? Collections.emptySet()
         : reviewRepository.findReviewedReservationIds(reservationIds);
+    log.info("Page<PossibleReviewResponseDto> reservations:{}", reviewedIds.size());
 
     // 4. 각 행사 DTO에 대해 reservationId가 reviewedIds Set에 있으면 hasReview = true 아니면 hasReview = false
     reservations.getContent()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 리뷰 작성 대상 예약 목록의 노출 범위를 확대하여 더 많은 예약을 확인하고 선택할 수 있습니다.
  * 과거/현재 시점에 한정되지 않고 조건에 맞는 예약이 표시됩니다.
  * 정렬, 취소 여부 필터, 페이지네이션 동작은 기존과 동일합니다.
* Chores
  * 모니터링을 위한 단계별 크기 로그를 추가하고 불필요한 의존성을 정리했습니다. 사용자 기능에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->