### PR TITLE
refactor: 당일 예약 이메일 발송 로직 참석자 정보 저장할때 호출

### DIFF
--- a/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
+++ b/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
@@ -11,11 +11,13 @@ import com.fairing.fairplay.attendee.repository.AttendeeRepositoryCustom;
 import com.fairing.fairplay.attendee.repository.AttendeeTypeCodeRepository;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.qr.dto.QrTicketEmailTodayRequestDto;
 import com.fairing.fairplay.qr.service.QrTicketService;
 import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.reservation.repository.ReservationRepository;
 import com.fairing.fairplay.shareticket.entity.ShareTicket;
 import com.fairing.fairplay.shareticket.service.ShareTicketService;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -57,6 +59,18 @@ public class AttendeeService {
     AttendeeInfoResponseDto attendeeInfoResponseDto = saveAttendee("GUEST", dto,
         shareTicket.getReservation().getReservationId());
     shareTicketService.updateShareTicket(shareTicket);
+
+    LocalDate today = LocalDate.now();
+    LocalDate reservationDate = shareTicket.getReservation().getCreatedAt().toLocalDate();
+    LocalDate scheduleDate = shareTicket.getReservation().getSchedule().getDate();
+    if(reservationDate.isEqual(today) && scheduleDate.isEqual(today)) {
+      QrTicketEmailTodayRequestDto qrTicketEmailTodayRequestDto = QrTicketEmailTodayRequestDto
+          .builder()
+          .attendeeId(attendeeInfoResponseDto.getAttendeeId())
+          .reservationId(attendeeInfoResponseDto.getReservationId())
+          .build();
+      qrTicketService.sendEmailGuest(qrTicketEmailTodayRequestDto);
+    }
     return attendeeInfoResponseDto;
   }
 

--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -84,7 +84,6 @@ public class SecurityConfig {
                                                                 "/api/booths/payment/request-from-email",
                                                                 "/api/booths/payment/complete",
                                                                 "/api/event-popularity/**",
-                                                                "/api/qr-tickets/send-email/guest",
                                                                 "/api/banner/hot-picks")
                                                 .permitAll()
                                                 .requestMatchers(HttpMethod.GET, "/api/reviews/*").permitAll()

--- a/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
+++ b/src/main/java/com/fairing/fairplay/qr/controller/QrTicketController.java
@@ -121,13 +121,6 @@ public class QrTicketController {
     return ResponseEntity.ok(entryExitService.adminForceCheck(dto));
   }
 
-  // 당일 예약 + 동반자 정보 저장 시 QR 티켓 발송
-  @PostMapping("/send-email/guest")
-  public ResponseEntity<Void> sendEmailGuest(@RequestBody QrTicketEmailTodayRequestDto dto){
-    qrTicketService.sendEmailGuest(dto);
-    return ResponseEntity.ok().build();
-  }
-
   // 참석자 자동 저장 테스트용 개발 코드
   @PostMapping("/test/schedule")
   public void scheduleTestAttendee(){

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketIssueService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketIssueService.java
@@ -274,7 +274,7 @@ public class QrTicketIssueService {
         .qrCode(null)
         .manualCode(null)
         .build();
-    qrTicketRepository.save(qrTicket);
+    qrTicketRepository.saveAndFlush(qrTicket);
 
     QrTicketRequestDto qrTicketRequestDto = QrTicketRequestDto.builder()
         .attendeeId(attendee.getId())

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketService.java
@@ -74,7 +74,6 @@ public class QrTicketService {
   }
 
   // QR 티켓 당일 발송
-  @Transactional
   public void sendEmailGuest(QrTicketEmailTodayRequestDto dto) {
     qrTicketIssueService.sendEmailGuest(dto);
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 동일 날짜에 생성·예약된 동행자 예약의 경우, 저장 시 QR 티켓 이메일이 자동 발송됩니다.
* Chores
  * 게스트용 QR 티켓 이메일 전송 엔드포인트가 더 이상 공개되지 않으며, 호출 시 인증이 필요합니다.
  * 이메일 전송 처리의 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->