### PR TITLE
feat: 일별 매출, 건수 dto 추가 및 집계

### DIFF
--- a/src/main/java/com/fairing/fairplay/statistics/dto/sales/SalesDailyTrendDto.java
+++ b/src/main/java/com/fairing/fairplay/statistics/dto/sales/SalesDailyTrendDto.java
@@ -1,0 +1,18 @@
+package com.fairing.fairplay.statistics.dto.sales;
+
+import jakarta.persistence.Column;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SalesDailyTrendDto {
+    private LocalDate statDate;
+    private Long totalSales = 0L;
+    private Integer totalCount = 0;
+}
+

--- a/src/main/java/com/fairing/fairplay/statistics/dto/sales/SalesDashboardResponse.java
+++ b/src/main/java/com/fairing/fairplay/statistics/dto/sales/SalesDashboardResponse.java
@@ -3,6 +3,7 @@ package com.fairing.fairplay.statistics.dto.sales;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -11,6 +12,7 @@ public class SalesDashboardResponse {
     private SummarySection summary;
     private List<StatusBreakdownItem> statusBreakdown;
     private List<SessionSalesItem> sessionSales;
+    private List<SalesDailyTrend> salesDailyTrend;
 
     @Getter
     @Builder
@@ -46,5 +48,14 @@ public class SalesDashboardResponse {
         private Integer quantity;
         private Long salesAmount;
         private String status;
+    }
+
+    @Getter
+    @Builder
+    public static class SalesDailyTrend {
+        private LocalDate date;
+        private Long amount;
+        private Integer count;
+
     }
 }

--- a/src/main/java/com/fairing/fairplay/statistics/repository/salesstats/SalesStatisticsCustomRepository.java
+++ b/src/main/java/com/fairing/fairplay/statistics/repository/salesstats/SalesStatisticsCustomRepository.java
@@ -1,6 +1,7 @@
 package com.fairing.fairplay.statistics.repository.salesstats;
 
 import com.fairing.fairplay.statistics.dto.sales.PaymentStatusSalesDto;
+import com.fairing.fairplay.statistics.dto.sales.SalesDailyTrendDto;
 import com.fairing.fairplay.statistics.dto.sales.SalesSummaryDto;
 import com.fairing.fairplay.statistics.dto.sales.SessionSalesDto;
 import java.time.LocalDate;
@@ -8,6 +9,9 @@ import java.util.List;
 
 public interface SalesStatisticsCustomRepository {
     SalesSummaryDto getSalesSummary(Long eventId, LocalDate start, LocalDate end);
+
+    List<SalesDailyTrendDto> getSalesDailyTrend(Long eventId, LocalDate start, LocalDate end);
+
     List<PaymentStatusSalesDto> getSalesByPaymentStatus(Long eventId, LocalDate start, LocalDate end);
     List<SessionSalesDto> getSessionSales(Long eventId, LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/fairing/fairplay/statistics/repository/salesstats/SalesStatisticsCustomRepositoryImpl.java
+++ b/src/main/java/com/fairing/fairplay/statistics/repository/salesstats/SalesStatisticsCustomRepositoryImpl.java
@@ -55,8 +55,8 @@ public class SalesStatisticsCustomRepositoryImpl implements SalesStatisticsCusto
     public List<SalesDailyTrendDto> getSalesDailyTrend(Long eventId, LocalDate start, LocalDate end) {
         List<Tuple> results = queryFactory
                 .select(
-                        daily.totalSales,
-                        daily.totalCount,
+                        daily.paidSales,
+                        daily.paidCount,
                         daily.statDate
                 )
                 .from(daily)
@@ -66,8 +66,8 @@ public class SalesStatisticsCustomRepositoryImpl implements SalesStatisticsCusto
 
         return results.stream()
                 .map(r -> SalesDailyTrendDto.builder()
-                        .totalSales(r.get(daily.totalSales) != null ? r.get(daily.totalSales) : 0L)
-                        .totalCount(r.get(daily.totalCount) != null ? r.get(daily.totalCount) : 0)
+                        .totalSales(r.get(daily.paidSales) != null ? r.get(daily.totalSales) : 0L)
+                        .totalCount(r.get(daily.paidCount) != null ? r.get(daily.totalCount) : 0)
                         .statDate(r.get(daily.statDate))
                         .build())
                 .toList();

--- a/src/main/java/com/fairing/fairplay/statistics/repository/salesstats/SalesStatisticsCustomRepositoryImpl.java
+++ b/src/main/java/com/fairing/fairplay/statistics/repository/salesstats/SalesStatisticsCustomRepositoryImpl.java
@@ -66,8 +66,8 @@ public class SalesStatisticsCustomRepositoryImpl implements SalesStatisticsCusto
 
         return results.stream()
                 .map(r -> SalesDailyTrendDto.builder()
-                        .totalSales(r.get(daily.paidSales) != null ? r.get(daily.totalSales) : 0L)
-                        .totalCount(r.get(daily.paidCount) != null ? r.get(daily.totalCount) : 0)
+                        .totalSales(r.get(daily.paidSales) != null ? r.get(daily.paidSales) : 0L)
+                        .totalCount(r.get(daily.paidCount) != null ? r.get(daily.paidCount) : 0)
                         .statDate(r.get(daily.statDate))
                         .build())
                 .toList();

--- a/src/main/java/com/fairing/fairplay/statistics/repository/salesstats/SalesStatisticsCustomRepositoryImpl.java
+++ b/src/main/java/com/fairing/fairplay/statistics/repository/salesstats/SalesStatisticsCustomRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.fairing.fairplay.statistics.repository.salesstats;
 
 import com.fairing.fairplay.statistics.dto.sales.PaymentStatusSalesDto;
 import com.fairing.fairplay.statistics.dto.sales.SalesSummaryDto;
+import com.fairing.fairplay.statistics.dto.sales.SalesDailyTrendDto;
 import com.fairing.fairplay.statistics.dto.sales.SessionSalesDto;
 import com.fairing.fairplay.statistics.entity.sales.QEventDailySalesStatistics;
 import com.fairing.fairplay.statistics.entity.sales.QEventSessionSalesStatistics;
@@ -49,6 +50,27 @@ public class SalesStatisticsCustomRepositoryImpl implements SalesStatisticsCusto
                 .refundedSales(result.get(daily.refundedSales.sum()))
                 .refundedCount(result.get(daily.refundedCount.sum()))
                 .build();
+    }
+    @Override
+    public List<SalesDailyTrendDto> getSalesDailyTrend(Long eventId, LocalDate start, LocalDate end) {
+        List<Tuple> results = queryFactory
+                .select(
+                        daily.totalSales,
+                        daily.totalCount,
+                        daily.statDate
+                )
+                .from(daily)
+                .where(daily.eventId.eq(eventId)
+                        .and(daily.statDate.between(start, end)))
+                .fetch();
+
+        return results.stream()
+                .map(r -> SalesDailyTrendDto.builder()
+                        .totalSales(r.get(daily.totalSales) != null ? r.get(daily.totalSales) : 0L)
+                        .totalCount(r.get(daily.totalCount) != null ? r.get(daily.totalCount) : 0)
+                        .statDate(r.get(daily.statDate))
+                        .build())
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/fairing/fairplay/statistics/service/sales/SalesStatisticsService.java
+++ b/src/main/java/com/fairing/fairplay/statistics/service/sales/SalesStatisticsService.java
@@ -18,11 +18,13 @@ public class SalesStatisticsService {
         SalesSummaryDto summary = getSummaryWithDefaults(eventId, start, end);
         List<PaymentStatusSalesDto> statusSales = defaultIfNull(salesRepo.getSalesByPaymentStatus(eventId, start, end));
         List<SessionSalesDto> sessionSales = defaultIfNull(salesRepo.getSessionSales(eventId, start, end));
+        List<SalesDailyTrendDto> salesDailyTrends =  defaultIfNull(salesRepo.getSalesDailyTrend(eventId, start, end));
 
         return SalesDashboardResponse.builder()
                 .summary(buildSummarySection(summary))
                 .statusBreakdown(buildStatusBreakdown(statusSales))
                 .sessionSales(buildSessionSales(sessionSales))
+                .salesDailyTrend(buildSalesDailyTrend(salesDailyTrends))
                 .build();
     }
 
@@ -53,6 +55,7 @@ public class SalesStatisticsService {
                 .toList();
     }
 
+
     private List<SalesDashboardResponse.SessionSalesItem> buildSessionSales(List<SessionSalesDto> list) {
         return list.stream()
                 .map(s -> SalesDashboardResponse.SessionSalesItem.builder()
@@ -62,6 +65,16 @@ public class SalesStatisticsService {
                         .quantity(safeInt(s.getQuantity()))
                         .salesAmount(safeLong(s.getSalesAmount()))
                         .status(statusLabel(s.getPaymentStatusCode()))
+                        .build())
+                .toList();
+    }
+
+    private List<SalesDashboardResponse.SalesDailyTrend> buildSalesDailyTrend(List<SalesDailyTrendDto> list) {
+        return list.stream()
+                .map(s -> SalesDashboardResponse.SalesDailyTrend.builder()
+                        .date(s.getStatDate())
+                        .amount(s.getTotalSales())
+                        .count(s.getTotalCount())
                         .build())
                 .toList();
     }


### PR DESCRIPTION
일별 매출의 매출 금액, 예약 건수 , 해당일을 가져올 수 있는 기능 추가 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 판매 대시보드에 일별 추세(날짜·매출액·주문건수) 섹션을 추가했습니다. 선택한 기간에 맞춰 일 단위 집계가 제공되며, 기존 지표는 그대로 유지됩니다. API 응답에 일별 추세 필드가 추가되어 차트/표 구성에 활용할 수 있습니다. 누락 값은 0으로 처리되어 공백일도 일관된 시계열 분석이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->