### PR TITLE
localhost로 저장되던 문제 수정

### DIFF
--- a/src/main/java/com/fairing/fairplay/banner/dto/CreateApplicationRequestDto.java
+++ b/src/main/java/com/fairing/fairplay/banner/dto/CreateApplicationRequestDto.java
@@ -20,10 +20,8 @@ public record CreateApplicationRequestDto(
         String title,
 
         @NotBlank(message = "이미지 URL은 필수입니다")
-        @URL(message = "올바른 이미지 URL 형식이어야 합니다")
         String imageUrl,
 
-        @URL(message = "올바른 링크 URL 형식이어야 합니다")
         String linkUrl,
 
         @NotEmpty(message = "아이템 목록은 비어있을 수 없습니다")

--- a/src/main/java/com/fairing/fairplay/core/service/AwsS3Service.java
+++ b/src/main/java/com/fairing/fairplay/core/service/AwsS3Service.java
@@ -63,8 +63,8 @@ public class AwsS3Service {
         log.info("Temporary file uploaded successfully - Key: {}, Original: {}, Size: {}",
                 key, file.getOriginalFilename(), file.getSize());
 
-        // 미리보기용 URL
-        String downloadUrl = baseUrl + "/api/uploads/download?key=" + URLEncoder.encode(key, StandardCharsets.UTF_8);
+        // 미리보기용 URL (상대 경로로 반환, 프론트엔드에서 baseUrl 추가)
+        String downloadUrl = "/api/uploads/download?key=" + URLEncoder.encode(key, StandardCharsets.UTF_8);
 
         // 이미지 여부
         boolean isImage = file.getContentType() != null && file.getContentType().startsWith("image/");

--- a/src/main/java/com/fairing/fairplay/event/service/EventService.java
+++ b/src/main/java/com/fairing/fairplay/event/service/EventService.java
@@ -821,7 +821,7 @@ public class EventService {
 
             fileService.createFileLink(savedFile, "EVENT", eventId);
 
-            String tempUrl = "https://fair-play.ink/api/uploads/download?key=" + fileDto.getS3Key();
+            String tempUrl = "/api/uploads/download?key=" + fileDto.getS3Key();
             String cdnUrl = awsS3Service.getCdnUrl(savedFile.getFileUrl());
 
             switch (fileDto.getUsage()) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 임시 업로드 미리보기/다운로드 링크를 상대 경로로 반환해 다양한 도메인·환경에서 정상 동작.
  * 이벤트 콘텐츠(본문/소개/정책) 내 임시 링크 인식 개선으로 CDN 링크 치환 안정화.

* 리팩터링
  * 신청 양식의 URL 검증 완화: 이미지/링크 URL 형식 검사를 제거해 입력 유연성 향상(이미지 URL은 공백만 검증).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->