### PR TITLE
fix: 영어 타이틀 dto 추가

### DIFF
--- a/src/main/java/com/fairing/fairplay/event/dto/EventSummaryDto.java
+++ b/src/main/java/com/fairing/fairplay/event/dto/EventSummaryDto.java
@@ -17,6 +17,7 @@ public class EventSummaryDto {  // 메인페이지, 검색 등에서 표시될 �
     private String eventCode;                   // [행사 담당자 전용] 행사 고유 코드
     private Boolean hidden;                   // [행사 담당자 전용] 일반 사용자에 숨겨진 상태
     private String title;                       // 국문 행사명
+    private String titleEng;
     private Integer minPrice;                   // 최소 가격
     private String mainCategory;          // 메인 카테고리
     private String location;                    // 장소명
@@ -42,7 +43,7 @@ public class EventSummaryDto {  // 메인페이지, 검색 등에서 표시될 �
     public EventSummaryDto(Long id, String eventCode, Boolean hidden, String title,
                            Integer minPrice, String mainCategory, String location,
                            BigDecimal latitude, BigDecimal longitude,
-                           LocalDate startDate, LocalDate endDate, String thumbnailUrl, String region, String statusCode) {
+                           LocalDate startDate, LocalDate endDate, String thumbnailUrl, String region, String statusCode, String titleEng) {
         this.id = id;
         this.eventCode = eventCode;
         this.hidden = hidden;
@@ -57,5 +58,6 @@ public class EventSummaryDto {  // 메인페이지, 검색 등에서 표시될 �
         this.thumbnailUrl = thumbnailUrl;
         this.region = region;
         this.statusCode = statusCode;
+        this.titleEng = titleEng;
     }
 }

--- a/src/main/java/com/fairing/fairplay/event/repository/EventQueryRepositoryImpl.java
+++ b/src/main/java/com/fairing/fairplay/event/repository/EventQueryRepositoryImpl.java
@@ -53,7 +53,8 @@ public class EventQueryRepositoryImpl implements EventQueryRepository {
                         detail.endDate,
                         detail.thumbnailUrl,
                         detail.regionCode.name,
-                        event.statusCode.code
+                        event.statusCode.code,
+                        event.titleEng
                 ))
                 .from(event)
                 .join(event.eventDetail, detail)
@@ -147,7 +148,8 @@ public class EventQueryRepositoryImpl implements EventQueryRepository {
                         detail.endDate,
                         detail.thumbnailUrl,
                         detail.regionCode.name,
-                        event.statusCode.code
+                        event.statusCode.code,
+                        event.titleEng
                 ))
                 .from(event)
                 .join(event.eventDetail, detail)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 이벤트 요약에 영문 제목 지원이 추가되었습니다. 지원되는 화면과 API 응답에서 영문 제목을 확인할 수 있어 다국어 표시와 검색이 용이합니다. 기존 필터·정렬 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->