### PR TITLE
fix: 코드래빗 반영

### DIFF
--- a/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepository.java
@@ -139,10 +139,11 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
              ON s.reservation_status_code_id = r.reservation_status_code_id
         WHERE s.code IN (:statuses)
           AND r.canceled = 0
-          AND r.created_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)
+          AND r.created_at >= DATE_SUB(CURDATE(), INTERVAL 7 DAY)
+          AND r.created_at < CURDATE()
         GROUP BY r.event_id
         HAVING bookedQty > 0
-        ORDER BY bookedQty DESC
+        ORDER BY bookedQty DESC, r.event_id ASC
         LIMIT :limit
         """, nativeQuery = true)
     List<Object[]> findEventBookingQuantitiesLastWeek(@Param("statuses") List<String> statuses, @Param("limit") int limit);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 지난주 예약 수 집계가 오늘을 제외한 정확한 7일 범위를 사용하도록 조정되어 대시보드/리포트의 수치가 더 정확해졌습니다.
  - 동일한 예약 수일 때 이벤트를 일관된 순서로 표시하도록 정렬 기준을 보완하여, 새로고침/페이지 이동 시 결과 목록의 재현성과 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->