### PR TITLE
이중결제, 이중예약 현상 해결

### DIFF
--- a/src/main/java/com/fairing/fairplay/attendee/repository/AttendeeRepository.java
+++ b/src/main/java/com/fairing/fairplay/attendee/repository/AttendeeRepository.java
@@ -15,6 +15,9 @@ public interface AttendeeRepository extends JpaRepository<Attendee, Long> {
 
   List<Attendee> findAllByReservation_ReservationIdOrderByIdAsc(Long reservationId);
 
+  // 해당 예약에 참석자가 존재하는지 확인
+  boolean existsByReservation_ReservationId(Long reservationId);
+
   Optional<Attendee> findByReservation_ReservationIdAndAttendeeTypeCode_Id(Long reservationId,
       Integer attendeeTypeCodeId);
 

--- a/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
@@ -233,7 +233,14 @@ public class PaymentService {
         // 6. 결제 완료 후 후속 처리
         processPaymentCompletionActions(savedPayment);
 
-        return PaymentResponseDto.fromEntity(savedPayment);
+        // 7. 후속 처리로 업데이트된 payment 정보를 다시 조회하여 반환
+        Payment updatedPayment = paymentRepository.findById(savedPayment.getPaymentId())
+                .orElse(savedPayment);
+        
+        System.out.println("🟢 [PaymentService] completePayment 반환 - paymentId: " + updatedPayment.getPaymentId() +
+                ", targetId: " + updatedPayment.getTargetId());
+        
+        return PaymentResponseDto.fromEntity(updatedPayment);
     }
 
     // 티켓 결제 전체 조회 (전체 관리자, 행사 관리자)
@@ -441,9 +448,14 @@ public class PaymentService {
                 // targetId가 null이면 결제 후 예매 생성해야 하는 상황
                 Long reservationId = createReservationAfterPayment(payment);
 
+                System.out.println("🔴 [PaymentService] 예매 생성 완료 - reservationId: " + reservationId);
+                
                 // payment의 targetId를 실제 예매 ID로 업데이트
                 payment.setTargetId(reservationId);
-                paymentRepository.save(payment);
+                Payment savedPayment = paymentRepository.save(payment);
+                
+                System.out.println("🔴 [PaymentService] payment 업데이트 완료 - paymentId: " + savedPayment.getPaymentId() +
+                        ", targetId: " + savedPayment.getTargetId());
 
                 System.out.println("결제 후 예매 생성 완료 - paymentId: " + payment.getPaymentId() +
                         ", reservationId: " + reservationId);
@@ -451,10 +463,10 @@ public class PaymentService {
                 // 예약 처리 성공 후 알림 발송
                 sendPaymentCompletionNotifications(payment, reservationId);
             } else {
-                // targetId가 이미 있는 경우: 별도의 예약 생성 플로우에서 처리 중이므로 
-                // 여기서는 추가 처리하지 않음 (중복 방지)
-                System.out.println("예약이 별도 플로우에서 처리 중 - paymentId: " + payment.getPaymentId() +
+                // targetId가 이미 있는 경우: 기존 예매에 대한 알림만 발송
+                System.out.println("기존 예약에 대한 알림 발송 - paymentId: " + payment.getPaymentId() +
                         ", targetId: " + payment.getTargetId());
+                sendPaymentCompletionNotifications(payment, payment.getTargetId());
             }
 
         } catch (Exception e) {

--- a/src/main/java/com/fairing/fairplay/reservation/controller/ReservationController.java
+++ b/src/main/java/com/fairing/fairplay/reservation/controller/ReservationController.java
@@ -36,6 +36,10 @@ public class ReservationController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam Long paymentId
                                                                     ) {
+        System.out.println("🔶 [ReservationController] createReservation 호출됨 - eventId: " + eventId + 
+                ", paymentId: " + paymentId + ", scheduleId: " + requestDto.getScheduleId() + 
+                ", ticketId: " + requestDto.getTicketId());
+                
         Long userId = userDetails.getUserId();
         requestDto.setEventId(eventId);
         Reservation reservation = reservationService.createReservation(requestDto, userId, paymentId);

--- a/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepository.java
@@ -16,6 +16,8 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
   List<Reservation> findByEvent_EventId(Long eventId);
 
   List<Reservation> findByUser_userId(Long userUserId);
+  
+  List<Reservation> findByUser_UserIdAndEvent_EventId(Long userId, Long eventId);
 
   Optional<Reservation> findByReservationIdAndUser_UserId(Long reservationId, Long userId);
 

--- a/src/main/java/com/fairing/fairplay/reservation/service/ReservationService.java
+++ b/src/main/java/com/fairing/fairplay/reservation/service/ReservationService.java
@@ -64,6 +64,10 @@ public class ReservationService {
     // 예약 신청 (결제 데이터 생성 이후 마지막에 결제 완료 상태로 저장)
     @Transactional
     public Reservation createReservation(ReservationRequestDto requestDto, Long userId, Long paymentId) {
+        
+        System.out.println("🔵 [ReservationService] createReservation 호출 - userId: " + userId + 
+                ", paymentId: " + paymentId + ", eventId: " + requestDto.getEventId() + 
+                ", scheduleId: " + requestDto.getScheduleId() + ", ticketId: " + requestDto.getTicketId());
 
         Event event = eventRepository.findById(requestDto.getEventId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 EVENT ID: " + requestDto.getEventId()));
@@ -116,6 +120,10 @@ public class ReservationService {
         Reservation reservation = new Reservation(event, schedule, ticket, user, requestDto.getQuantity(), requestDto.getPrice());
         reservation.setReservationStatusCode(confirmedStatus);
         Reservation savedReservation = reservationRepository.save(reservation);
+        
+        System.out.println("🔵 [ReservationService] 예매 생성 완료 - reservationId: " + savedReservation.getReservationId() + 
+                ", eventId: " + savedReservation.getEvent().getEventId() + 
+                ", scheduleId: " + (savedReservation.getSchedule() != null ? savedReservation.getSchedule().getScheduleId() : null));
 
         Payment payment = paymentRepository.findById(paymentId).orElseThrow();
         

--- a/src/main/java/com/fairing/fairplay/shareticket/repository/ShareTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/repository/ShareTicketRepository.java
@@ -33,5 +33,7 @@ public interface ShareTicketRepository extends JpaRepository<ShareTicket, Long> 
 
   boolean existsByReservation_ReservationId(Long reservationId);
 
+  Optional<ShareTicket> findByReservation_ReservationId(Long reservationId);
+
   Optional<ShareTicket> findByReservation(Reservation reservation);
 }

--- a/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketAttendeeService.java
+++ b/src/main/java/com/fairing/fairplay/shareticket/service/ShareTicketAttendeeService.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Base64;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +47,9 @@ public class ShareTicketAttendeeService {
     if (userDetails == null || dto.getReservationId() == null) {
       throw new CustomException(HttpStatus.UNAUTHORIZED, "로그인 후 이용해주세요");
     }
+    
+    log.info("[ShareTicketAttendeeService] 시작 - 전달받은 reservationId: {}, totalAllowed: {}", 
+        dto.getReservationId(), dto.getTotalAllowed());
 
     // 1. attendee 저장
     Users buyUser = userRepository.findByUserId(userDetails.getUserId()).orElseThrow(
@@ -58,6 +62,38 @@ public class ShareTicketAttendeeService {
 
     if (!reservation.getUser().getUserId().equals(buyUser.getUserId())) {
       throw new CustomException(HttpStatus.FORBIDDEN, "해당 예약에 대한 권한이 없습니다.");
+    }
+
+    // 강력한 중복 처리 방지 체크
+    // 1. 해당 예약에 attendee가 이미 존재하는지 확인
+    if (attendeeService.existsByReservationId(dto.getReservationId())) {
+      log.info("[ShareTicketAttendeeService] 이미 참석자가 등록된 예약입니다 - reservationId: {}", dto.getReservationId());
+      // 기존 데이터 반환
+      String existingToken = shareTicketRepository.findByReservation_ReservationId(dto.getReservationId())
+          .map(shareTicket -> shareTicket.getLinkToken())
+          .orElse(null);
+      return ShareTicketSaveResponseDto.builder()
+          .reservationId(dto.getReservationId())
+          .token(existingToken)
+          .build();
+    }
+    
+    // 2. 동일한 사용자의 동일한 이벤트에 대한 중복 처리 확인
+    List<Reservation> existingReservations = reservationRepository
+        .findByUser_UserIdAndEvent_EventId(buyUser.getUserId(), reservation.getEvent().getEventId());
+    for (Reservation existingReservation : existingReservations) {
+      if (attendeeService.existsByReservationId(existingReservation.getReservationId())) {
+        log.info("[ShareTicketAttendeeService] 동일 사용자의 동일 이벤트에 대한 중복 처리 방지 - userId: {}, eventId: {}, existingReservationId: {}", 
+            buyUser.getUserId(), reservation.getEvent().getEventId(), existingReservation.getReservationId());
+        // 기존 예약의 데이터 반환
+        String existingToken = shareTicketRepository.findByReservation_ReservationId(existingReservation.getReservationId())
+            .map(shareTicket -> shareTicket.getLinkToken())
+            .orElse(null);
+        return ShareTicketSaveResponseDto.builder()
+            .reservationId(existingReservation.getReservationId())
+            .token(existingToken)
+            .build();
+      }
     }
 
     AttendeeSaveRequestDto attendeeSaveRequestDto = AttendeeSaveRequestDto.builder()

--- a/src/main/resources/email/payment-completion.html
+++ b/src/main/resources/email/payment-completion.html
@@ -32,7 +32,8 @@
         .header img {
             width: 64px;
             height: 64px;
-            margin-bottom: 16px;
+            margin: 0 auto 16px auto;
+            display: block;
             object-fit: contain;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 결제 완료 처리 시 기존 예약에도 알림이 정상 발송되도록 개선하여 알림 누락 사례를 방지했습니다.
  - 공유티켓/참가자 생성 과정에서 중복 생성을 차단하고, 이미 존재하는 경우 기존 토큰을 바로 반환하도록 했습니다. 이에 따라 불필요한 재발급이 줄고 일관성이 향상됩니다.

- 스타일
  - 결제 완료 이메일에서 헤더 로고가 중앙 정렬되도록 시각적 레이아웃을 개선했습니다(하단 간격 유지).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->