### PR TITLE
rag 범위 확장

### DIFF
--- a/src/main/java/com/fairing/fairplay/ai/orchestrator/AiChatOrchestrator.java
+++ b/src/main/java/com/fairing/fairplay/ai/orchestrator/AiChatOrchestrator.java
@@ -102,11 +102,11 @@ public class AiChatOrchestrator {
             return;
         }
 
-        // RAG 기반 응답 생성
+        // RAG 기반 응답 생성 (사용자 ID 포함)
         String reply;
         try {
-            System.out.println("RAG 채팅 호출 시작...");
-            RagChatService.RagResponse ragResponse = ragChatService.chat(userQuestion, conversationHistory);
+            System.out.println("RAG 채팅 호출 시작... (사용자 ID: " + room.getUserId() + ")");
+            RagChatService.RagResponse ragResponse = ragChatService.chat(userQuestion, conversationHistory, room.getUserId());
             
             reply = ragResponse.getAnswer();
             

--- a/src/main/java/com/fairing/fairplay/ai/rag/controller/RagAdminController.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/controller/RagAdminController.java
@@ -143,6 +143,11 @@ public class RagAdminController {
                         "total", result.categoryResult.getTotalCount(),
                         "success", result.categoryResult.getSuccessCount(),
                         "fail", result.categoryResult.getFailCount()
+                    ),
+                    "userData", Map.of(
+                        "total", result.userDataResult.getTotalCount(),
+                        "success", result.userDataResult.getSuccessCount(),
+                        "fail", result.userDataResult.getFailCount()
                     )
                 )
             ));

--- a/src/main/java/com/fairing/fairplay/ai/rag/service/RagChatService.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/RagChatService.java
@@ -29,6 +29,13 @@ public class RagChatService {
      * RAG 기반 질의 응답
      */
     public RagResponse chat(String userQuestion, List<ChatMessageDto> conversationHistory) {
+        return chat(userQuestion, conversationHistory, null);
+    }
+    
+    /**
+     * RAG 기반 질의 응답 (사용자 ID 포함)
+     */
+    public RagResponse chat(String userQuestion, List<ChatMessageDto> conversationHistory, Long userId) {
         try {
             if (userQuestion == null || userQuestion.trim().isEmpty()) {
                 log.warn("빈 사용자 질문 수신: RAG 검색 생략");
@@ -38,15 +45,31 @@ public class RagChatService {
             // 벡터 검색으로 관련 컨텍스트 찾기
             SearchResult searchResult = vectorSearchService.search(userQuestion);
             
-            boolean hasRelevantContext = !searchResult.getChunks().isEmpty() &&
-                searchResult.getChunks().get(0).getSimilarity() > CONTEXT_REQUIRED_THRESHOLD;
+            // 개인정보 관련 질문인지 확인하고 사용자별 검색 추가
+            boolean isPersonalQuery = isPersonalInformationQuery(userQuestion);
+            SearchResult userSearchResult = null;
+            
+            if (isPersonalQuery && userId != null) {
+                // 사용자 개인정보 검색
+                userSearchResult = vectorSearchService.searchUserData(userId, userQuestion);
+                log.info("사용자 개인정보 검색 수행: userId={}, 결과={}", userId, 
+                    userSearchResult.getChunks().size());
+            }
+            
+            // 사용자 개인정보가 우선순위가 높음
+            boolean hasUserContext = userSearchResult != null && !userSearchResult.getChunks().isEmpty();
+            boolean hasRelevantContext = hasUserContext || 
+                (!searchResult.getChunks().isEmpty() && searchResult.getChunks().get(0).getSimilarity() > CONTEXT_REQUIRED_THRESHOLD);
+            
+            // 최종 컨텍스트 결정 (사용자 정보 우선)
+            SearchResult finalSearchResult = hasUserContext ? userSearchResult : searchResult;
             
             // 프롬프트 구성
             List<ChatMessageDto> prompt = new ArrayList<>();
             
             if (hasRelevantContext) {
                 // RAG 시스템 프롬프트 (컨텍스트 포함)
-                prompt.add(ChatMessageDto.system(buildRagSystemPrompt(searchResult.getContextText())));
+                prompt.add(ChatMessageDto.system(buildRagSystemPrompt(finalSearchResult.getContextText())));
             } else {
                 // 일반 시스템 프롬프트
                 prompt.add(ChatMessageDto.system("""
@@ -81,7 +104,7 @@ public class RagChatService {
             response = response.replaceAll("\\*\\*([^*]+)\\*\\*", "$1");
             
             // 인용 정보 구성
-            List<CitedChunk> citedChunks = searchResult.getChunks().stream()
+            List<CitedChunk> citedChunks = finalSearchResult.getChunks().stream()
                 .map(chunk -> new CitedChunk(
                     chunk.getChunk().getChunkId(),
                     chunk.getChunk().getDocId(),
@@ -100,7 +123,7 @@ public class RagChatService {
                 .answer(response)
                 .hasContext(hasRelevantContext)
                 .citedChunks(citedChunks)
-                .totalSearched(searchResult.getTotalChunks())
+                .totalSearched(finalSearchResult.getTotalChunks())
                 .build();
                 
         } catch (Exception e) {
@@ -112,34 +135,61 @@ public class RagChatService {
     }
     
     /**
+     * 개인정보 관련 질문인지 확인
+     */
+    private boolean isPersonalInformationQuery(String question) {
+        if (question == null) return false;
+        
+        String lowerQuestion = question.toLowerCase();
+        return lowerQuestion.contains("내 ") || 
+               lowerQuestion.contains("나의 ") ||
+               lowerQuestion.contains("내가 ") ||
+               lowerQuestion.contains("예약") ||
+               lowerQuestion.contains("티켓") ||
+               lowerQuestion.contains("개인정보") ||
+               lowerQuestion.contains("프로필") ||
+               lowerQuestion.contains("내정보");
+    }
+    
+    /**
      * RAG 시스템 프롬프트 구성
      */
     private String buildRagSystemPrompt(String contextText) {
         return String.format("""
-            안녕! 나는 '페어링'이야, FairPlay 플랫폼의 친근한 AI 도우미야. 
-            사용자가 이벤트나 공연에 대해 궁금해하면, 마치 현지 가이드처럼 자연스럽고 도움이 되는 정보를 제공해줄게!
+            안녕! 나는 '페어링'이야, FairPlay 플랫폼의 친근한 AI 도우미야! 
+            사용자가 이벤트, 예약, 개인정보 등에 대해 궁금해하면 도움이 되는 정보를 제공해줄게!
             
-            **참고할 이벤트 정보:**
+            **참고할 정보:**
             %s
             
-            **중요한 답변 규칙:**
-            ⚠️ **반드시 위의 참고 정보와 사용자 질문의 관련성을 먼저 확인해야 합니다!**
+            **답변 가이드라인:**
             
-            1. **관련성 확인**: 위 참고 정보가 사용자가 묻는 이벤트/축제와 직접적으로 관련이 있나요?
-               - 만약 사용자가 "송도 맥주축제"를 물어봤는데 참고 정보가 예매/취소/환불 정책만 있다면 → "관련 없음"
-               - 만약 사용자가 물어본 이벤트명이 참고 정보에 명시적으로 포함되어 있다면 → "관련 있음"
+            📋 **개인정보 관련 질문 (내 예약, 내 티켓, 내 정보 등)**:
+            - "내 예약 내역", "내 티켓 정보", "내 개인정보" 등의 질문 시
+            - 위 참고 정보에서 해당 사용자의 정보를 찾아 정확히 제공
+            - 예약 상태, 이벤트명, 날짜, 가격 등 상세 정보 포함
+            - 개인정보는 해당 사용자에게만 제공 (보안 유지)
             
-            2. **관련 있을 때**: 위 정보를 바탕으로 자연스럽게 답변
-               - 날짜, 장소, 주요 내용을 중심으로 간결하게 정리
-               - 예약이나 참가 방법 같은 실용적인 팁도 함께 제공
+            🎪 **이벤트 정보 관련 질문**:
+            - 특정 이벤트, 축제, 부스에 대한 질문 시
+            - 위 참고 정보에서 관련 내용을 찾아 제공
+            - 날짜, 장소, 설명, 티켓 정보, 부스 정보 등 포함
             
-            3. **관련 없을 때**: 다음과 같이 정직하게 답변
-               "죄송해요! 현재 제가 가지고 있는 정보에서는 [사용자가 물어본 이벤트명]에 대한 구체적인 정보를 찾을 수 없어요. 
-               정확한 정보는 해당 이벤트의 공식 홈페이지나 주최측에 직접 문의하시는 것을 추천드려요! 😊"
+            🎫 **부스 및 체험 정보**:
+            - 특정 이벤트의 부스 정보나 체험 프로그램 질문 시
+            - 부스명, 위치, 체험 내용, 소요시간, 참가자 수 등 제공
             
-            **절대 하지 말 것:**
-            - 참고 정보에 없는 내용을 추측해서 만들어내지 말 것
-            - 일반적인 축제 정보로 대충 답변하지 말 것
+            ✅ **답변 원칙**:
+            1. 참고 정보에 있는 내용만 정확히 제공
+            2. 개인정보는 해당 사용자 것만 표시
+            3. 정보가 없으면 솔직히 "찾을 수 없어요" 안내
+            4. 친근하고 자연스러운 한국어로 답변
+            5. 중요 정보는 구조화해서 보기 쉽게 정리
+            
+            ❌ **금지사항**:
+            - 참고 정보에 없는 내용 추측하지 말 것
+            - 다른 사용자의 개인정보 노출하지 말 것
+            - 부정확한 정보 제공하지 말 것
             """, contextText);
     }
     

--- a/src/main/java/com/fairing/fairplay/ai/rag/service/VectorSearchService.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/VectorSearchService.java
@@ -581,6 +581,224 @@ public class VectorSearchService {
     }
     
     /**
+     * 공개 정보만 검색 (사용자 개인정보 제외)
+     * 일반 질문에 대해 공개된 이벤트, 부스 정보만 검색
+     */
+    public SearchResult searchPublicOnly(String query) throws Exception {
+        if (query == null || query.trim().isEmpty()) {
+            return SearchResult.builder()
+                .chunks(Collections.emptyList())
+                .contextText("")
+                .totalChunks(0)
+                .build();
+        }
+        
+        // 캐시 초기화
+        initializeCacheIfNeeded();
+        
+        // 사용자 개인정보(user_xxx) 문서를 제외한 공개 정보만 필터링
+        List<Chunk> publicChunks = chunkCache.values().stream()
+            .filter(chunk -> !chunk.getDocId().startsWith("user_"))
+            .collect(Collectors.toList());
+        
+        log.info("공개 정보 전용 청크 개수: {} (전체: {})", publicChunks.size(), chunkCache.size());
+        
+        if (publicChunks.isEmpty()) {
+            return SearchResult.builder()
+                .chunks(Collections.emptyList())
+                .contextText("검색할 수 있는 공개 정보가 없습니다.")
+                .totalChunks(0)
+                .build();
+        }
+        
+        // 질의 임베딩 생성
+        float[] queryEmbedding = embeddingService.embedQuery(query);
+        
+        // 공개 청크와 유사도 계산
+        List<SearchResult.ScoredChunk> scoredChunks = new ArrayList<>();
+        
+        for (Chunk chunk : publicChunks) {
+            if (chunk.getEmbedding() == null) {
+                log.warn("공개 청크 {}에 임베딩이 없습니다.", chunk.getChunkId());
+                continue;
+            }
+            
+            double similarity = embeddingService.calculateCosineSimilarity(
+                queryEmbedding, chunk.getEmbedding()
+            );
+            
+            if (similarity >= SIMILARITY_THRESHOLD) {
+                scoredChunks.add(SearchResult.ScoredChunk.builder()
+                    .chunk(chunk)
+                    .similarity(similarity)
+                    .build());
+            }
+        }
+        
+        // 공개 정보도 키워드 검색으로 보완 (한글 지원)
+        boolean needKeywordSearch = scoredChunks.size() < DEFAULT_TOP_K / 2;
+        if (!needKeywordSearch && !scoredChunks.isEmpty()) {
+            double maxSimilarity = scoredChunks.get(0).getSimilarity();
+            needKeywordSearch = maxSimilarity < 0.5;
+        }
+        
+        // 한글 쿼리는 항상 키워드 검색 추가
+        if (containsKorean(query)) {
+            needKeywordSearch = true;
+        }
+        
+        if (needKeywordSearch) {
+            // 공개 정보만 대상으로 키워드 검색
+            SearchResult keywordResult = performPublicKeywordSearch(query, publicChunks, DEFAULT_TOP_K);
+            return combinePublicSearchResults(scoredChunks, keywordResult, DEFAULT_TOP_K, query);
+        }
+        
+        // 유사도 순 정렬 및 Top-K 선택
+        List<SearchResult.ScoredChunk> topChunks = scoredChunks.stream()
+            .sorted((a, b) -> Double.compare(b.getSimilarity(), a.getSimilarity()))
+            .limit(DEFAULT_TOP_K)
+            .collect(Collectors.toList());
+        
+        String contextText = buildContextText(topChunks);
+        
+        log.info("공개 정보 검색 완료: 총 {} 청크 중 {} 개 반환", 
+            publicChunks.size(), topChunks.size());
+        
+        return SearchResult.builder()
+            .chunks(topChunks)
+            .contextText(contextText)
+            .totalChunks(publicChunks.size())
+            .build();
+    }
+    
+    /**
+     * 공개 정보만 대상으로 키워드 검색 수행
+     */
+    private SearchResult performPublicKeywordSearch(String query, List<Chunk> publicChunks, int topK) {
+        List<SearchResult.ScoredChunk> keywordMatches = new ArrayList<>();
+        
+        String normalizedQuery = query.trim();
+        String[] keywords = normalizedQuery.split("\\s+");
+        
+        for (Chunk chunk : publicChunks) {
+            String chunkText = chunk.getText();
+            double score = 0.0;
+            
+            // 키워드별 점수 계산 (기존 로직 재사용)
+            for (String keyword : keywords) {
+                if (keyword.length() < 1) continue;
+                
+                if (containsIgnoreCase(chunkText, keyword)) {
+                    score += 10.0;
+                    if (isInImportantField(chunkText, keyword)) {
+                        score += 20.0;
+                    }
+                }
+                
+                if (keyword.length() >= 2 && isKorean(keyword)) {
+                    for (int i = 0; i <= keyword.length() - 2; i++) {
+                        String partial = keyword.substring(i, Math.min(i + 2, keyword.length()));
+                        if (containsIgnoreCase(chunkText, partial)) {
+                            score += 2.0;
+                        }
+                    }
+                }
+                
+                if (keyword.length() >= 3 && isEnglish(keyword)) {
+                    for (int i = 0; i <= keyword.length() - 3; i++) {
+                        String partial = keyword.substring(i, Math.min(i + 3, keyword.length()));
+                        if (containsIgnoreCase(chunkText, partial)) {
+                            score += 1.0;
+                        }
+                    }
+                }
+            }
+            
+            if (containsIgnoreCase(chunkText, normalizedQuery)) {
+                score += 50.0;
+            }
+            
+            if (score > 0) {
+                double normalizedScore = Math.min(score / keywords.length, 100.0);
+                keywordMatches.add(SearchResult.ScoredChunk.builder()
+                    .chunk(chunk)
+                    .similarity(normalizedScore)
+                    .build());
+            }
+        }
+        
+        List<SearchResult.ScoredChunk> topKeywordChunks = keywordMatches.stream()
+            .sorted((a, b) -> Double.compare(b.getSimilarity(), a.getSimilarity()))
+            .limit(topK)
+            .collect(Collectors.toList());
+        
+        return SearchResult.builder()
+            .chunks(topKeywordChunks)
+            .contextText(buildContextText(topKeywordChunks))
+            .totalChunks(publicChunks.size())
+            .build();
+    }
+    
+    /**
+     * 공개 정보 벡터 검색과 키워드 검색 결과 결합
+     */
+    private SearchResult combinePublicSearchResults(List<SearchResult.ScoredChunk> vectorChunks, 
+                                                   SearchResult keywordResult, int topK, String query) {
+        Set<String> seenChunkIds = new HashSet<>();
+        List<SearchResult.ScoredChunk> combinedChunks = new ArrayList<>();
+        
+        boolean isKoreanQuery = containsKorean(query);
+        
+        if (isKoreanQuery && !keywordResult.getChunks().isEmpty()) {
+            // 한글 쿼리: 키워드 검색 우선
+            for (SearchResult.ScoredChunk chunk : keywordResult.getChunks()) {
+                if (!seenChunkIds.contains(chunk.getChunk().getChunkId())) {
+                    SearchResult.ScoredChunk boostedChunk = SearchResult.ScoredChunk.builder()
+                        .chunk(chunk.getChunk())
+                        .similarity(Math.min(chunk.getSimilarity() * 1.5, 1.0))
+                        .build();
+                    combinedChunks.add(boostedChunk);
+                    seenChunkIds.add(chunk.getChunk().getChunkId());
+                }
+            }
+            
+            // 벡터 검색 결과 추가
+            for (SearchResult.ScoredChunk chunk : vectorChunks) {
+                if (!seenChunkIds.contains(chunk.getChunk().getChunkId()) && combinedChunks.size() < topK) {
+                    combinedChunks.add(chunk);
+                    seenChunkIds.add(chunk.getChunk().getChunkId());
+                }
+            }
+        } else {
+            // 영어 쿼리: 벡터 검색 우선
+            for (SearchResult.ScoredChunk chunk : vectorChunks) {
+                if (!seenChunkIds.contains(chunk.getChunk().getChunkId())) {
+                    combinedChunks.add(chunk);
+                    seenChunkIds.add(chunk.getChunk().getChunkId());
+                }
+            }
+            
+            for (SearchResult.ScoredChunk chunk : keywordResult.getChunks()) {
+                if (!seenChunkIds.contains(chunk.getChunk().getChunkId()) && combinedChunks.size() < topK) {
+                    combinedChunks.add(chunk);
+                    seenChunkIds.add(chunk.getChunk().getChunkId());
+                }
+            }
+        }
+        
+        combinedChunks = combinedChunks.stream()
+            .sorted((a, b) -> Double.compare(b.getSimilarity(), a.getSimilarity()))
+            .limit(topK)
+            .collect(Collectors.toList());
+        
+        return SearchResult.builder()
+            .chunks(combinedChunks)
+            .contextText(buildContextText(combinedChunks))
+            .totalChunks(keywordResult.getTotalChunks())
+            .build();
+    }
+    
+    /**
      * 캐시 상태 확인
      */
     public Map<String, Object> getCacheStatus() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 사용자 데이터 RAG 통합: 사용자별 문서 생성(기본정보, 예약, 참석자, 리뷰 등) 및 임베딩·인입 지원. AI 봇 계정은 제외.
  - 개인화 검색·챗 호출: 특정 사용자 데이터 전용 검색과 공개 전용 검색 API 추가, 챗 호출 시 사용자 ID 전달로 개인문맥 우선 적용.
  - 관리자 응답에 userData 통계(total/success/fail) 항목 추가.

- 개선
  - 부스 문서에 배너, 유형, 관리자, 관련 행사·체험 정보 포함으로 임베딩 품질 향상.
  - 데이터베이스 상태 보고서에 사용자·예약 집계 추가 및 전체 로드 요약에 사용자 데이터 반영.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->