### PR TITLE
fix: 전자명함 qr 생성

### DIFF
--- a/src/main/java/com/fairing/fairplay/businesscard/service/BusinessCardService.java
+++ b/src/main/java/com/fairing/fairplay/businesscard/service/BusinessCardService.java
@@ -86,7 +86,8 @@ public class BusinessCardService {
         Users user = getUserById(userId);
         
         // 전자명함이 있는지 확인
-        if (!businessCardRepository.existsByUser(user)) {
+        BusinessCard businessCard = businessCardRepository.findByUser(user).orElse(null);
+        if (businessCard == null) {
             throw new CustomException(HttpStatus.NOT_FOUND, "전자명함을 먼저 생성해주세요.");
         }
         
@@ -106,7 +107,8 @@ public class BusinessCardService {
         Users cardOwner = getUserById(cardOwnerId);
         
         // 명함이 존재하는지 확인
-        if (!businessCardRepository.existsByUser(cardOwner)) {
+        BusinessCard cardOwnerBusinessCard = businessCardRepository.findByUser(cardOwner).orElse(null);
+        if (cardOwnerBusinessCard == null) {
             throw new CustomException(HttpStatus.NOT_FOUND, "해당 사용자의 전자명함이 존재하지 않습니다.");
         }
         


### PR DESCRIPTION
qr 생성 시 이미 내용이 있는데 저장하라고 하는 문제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 명함 QR 코드 생성 시, 존재하지 않는 사용자에 대한 검증을 강화하여 적절한 “찾을 수 없음” 오류를 일관되게 반환합니다.
  - 명함 수집 과정에서 소유자 미존재 상황을 정확히 감지하고 오류를 명확히 안내해 예기치 않은 실패를 줄였습니다.
  - 위 개선으로 오류 메시지의 명확성과 처리 일관성이 향상되어, 관련 기능 이용 시 신뢰성과 안정성이 높아졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->